### PR TITLE
feat: ensure persona ignores account owner

### DIFF
--- a/app/api/chat-summary/route.ts
+++ b/app/api/chat-summary/route.ts
@@ -12,10 +12,14 @@ export async function POST(req: Request) {
       return new Response("Transcript invalide", { status: 400 })
     }
 
+    const privacyPrompt =
+      "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Base ton analyse uniquement sur la transcription fournie."
+
     const completion = await client.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0.5,
       messages: [
+        { role: "system", content: privacyPrompt },
         {
           role: "system",
           content: `Tu es un évaluateur professionnel d'entretien simulé.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -36,6 +36,8 @@ export async function POST(req: Request) {
   const persona = (body.persona || "manager").toLowerCase()
   const lastUserMessage = (body.lastUserMessage || "").trim()
   const systemPrompt = PERSONA_PROMPTS[persona] ?? PERSONA_PROMPTS.manager
+  const privacyPrompt =
+    "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Réponds uniquement sur la base des messages fournis dans cette conversation."
 
   if (!lastUserMessage) {
     return new Response("Message utilisateur manquant.", { status: 400 })
@@ -48,6 +50,7 @@ export async function POST(req: Request) {
       temperature: 0.6,
       messages: [
         { role: "system", content: systemPrompt },
+        { role: "system", content: privacyPrompt },
         {
           role: "user",
           content:


### PR DESCRIPTION
## Summary
- instruct chat persona to ignore account owner details
- add privacy guard for chat summary generation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c30207104c8331826f733e1d5d5e8e