### PR TITLE
Handle empty transcript in chat summary API

### DIFF
--- a/app/api/chat-summary/route.ts
+++ b/app/api/chat-summary/route.ts
@@ -12,6 +12,13 @@ export async function POST(req: Request) {
       return new Response("Transcript invalide", { status: 400 })
     }
 
+    if (!transcript.length) {
+      return new Response(
+        JSON.stringify({ summary: "⚠️ Aucune conversation fournie." }),
+        { headers: { "Content-Type": "application/json" } }
+      )
+    }
+
     const privacyPrompt =
       "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Base ton analyse uniquement sur la transcription fournie."
 


### PR DESCRIPTION
## Summary
- Return early with warning when transcript array is empty
- Avoid unnecessary OpenAI call for empty transcripts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c30572a63483318a9390821d22b130