### PR TITLE
Handle empty transcript and analyze user messages in chat summary API

### DIFF
--- a/app/api/chat-summary/route.ts
+++ b/app/api/chat-summary/route.ts
@@ -12,6 +12,24 @@ export async function POST(req: Request) {
       return new Response("Transcript invalide", { status: 400 })
     }
 
+    if (!transcript.length) {
+      return new Response(
+        JSON.stringify({ summary: "⚠️ Aucune conversation fournie." }),
+        { headers: { "Content-Type": "application/json" } }
+      )
+    }
+
+    const userOnlyTranscript = transcript.filter(
+      (msg: { role: string }) => msg.role === "user"
+    )
+
+    if (!userOnlyTranscript.length) {
+      return new Response(
+        JSON.stringify({ summary: "⚠️ Aucune intervention utilisateur à analyser." }),
+        { headers: { "Content-Type": "application/json" } }
+      )
+    }
+
     const privacyPrompt =
       "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Base ton analyse uniquement sur la transcription fournie."
 
@@ -22,7 +40,7 @@ export async function POST(req: Request) {
         { role: "system", content: privacyPrompt },
         {
           role: "system",
-          content: `Tu es un évaluateur professionnel d'entretien simulé.
+          content: `Tu es un évaluateur professionnel d'entretien simulé. Évalue uniquement la qualité des interventions de l'utilisateur face à l'assistant, sans juger les réponses de l'assistant.
 Rédige un rapport clair et concis en français, au format Markdown, avec la structure suivante :
 
 # Rapport de simulation d’entretien
@@ -40,7 +58,7 @@ Sois bienveillant, précis et orienté action.`,
         },
         {
           role: "user",
-          content: JSON.stringify(transcript),
+          content: JSON.stringify(userOnlyTranscript),
         },
       ],
     })


### PR DESCRIPTION
## Summary
- Return early with warning when transcript array is empty
- Focus analysis on user turns only and ignore assistant responses

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c30572a63483318a9390821d22b130