### PR TITLE
feat: add PDF export for conversation

### DIFF
--- a/app/components/Controls.tsx
+++ b/app/components/Controls.tsx
@@ -1,10 +1,45 @@
 "use client"
 
+import { Message } from "@/app/components/MessageList"
+import jsPDF from "jspdf"
+
 type Props = {
   onClear: () => void
+  messages: Message[]
+  summary: string | null
 }
 
-export default function Controls({ onClear }: Props) {
+export default function Controls({ onClear, messages, summary }: Props) {
+  const handleDownload = () => {
+    if (!summary) return
+    const doc = new jsPDF()
+    let y = 10
+
+    messages.forEach(msg => {
+      const role =
+        msg.role === "user"
+          ? "Utilisateur"
+          : msg.role === "assistant"
+          ? "Assistant"
+          : "Erreur"
+      const lines = doc.splitTextToSize(`${role} : ${msg.content}`, 180)
+      if (y + lines.length * 7 > 280) {
+        doc.addPage()
+        y = 10
+      }
+      doc.text(lines, 10, y)
+      y += lines.length * 7
+    })
+
+    doc.addPage()
+    doc.setFont("helvetica", "bold")
+    doc.text("Synthèse", 10, 10)
+    doc.setFont("helvetica", "normal")
+    const summaryLines = doc.splitTextToSize(summary, 180)
+    doc.text(summaryLines, 10, 20)
+    doc.save("conversation.pdf")
+  }
+
   return (
     <div className="flex gap-3 justify-center">
       <button
@@ -13,6 +48,14 @@ export default function Controls({ onClear }: Props) {
       >
         Effacer la conversation
       </button>
+      {summary && (
+        <button
+          onClick={handleDownload}
+          className="rounded-2xl bg-blue-600 px-4 py-2 text-white shadow hover:bg-blue-700"
+        >
+          Télécharger le PDF
+        </button>
+      )}
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -158,25 +158,25 @@ export default function InterviewPage() {
         <div className="rounded-2xl shadow bg-green-50 text-green-900 border border-green-300 p-6">
           <ReactMarkdown
             components={{
-              h1: ({node, ...props}) => (
+              h1: ({ ...props }) => (
                 <h1
                   className="text-2xl font-bold text-green-800 mb-4 border-b pb-2"
                   {...props}
                 />
               ),
-              h2: ({node, ...props}) => (
+              h2: ({ ...props }) => (
                 <h2
                   className="text-xl font-semibold text-green-700 mt-4 mb-2"
                   {...props}
                 />
               ),
-              ul: ({node, ...props}) => (
+              ul: ({ ...props }) => (
                 <ul className="list-disc list-inside space-y-1" {...props} />
               ),
-              li: ({node, ...props}) => (
+              li: ({ ...props }) => (
                 <li className="leading-snug" {...props} />
               ),
-              p: ({node, ...props}) => (
+              p: ({ ...props }) => (
                 <p className="my-1 leading-relaxed" {...props} />
               ),
             }}
@@ -192,7 +192,7 @@ export default function InterviewPage() {
         }
         disabled={timerState !== "running"}
       />
-      <Controls onClear={handleClear} />
+      <Controls onClear={handleClear} messages={messages} summary={summary} />
     </main>
   )
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "openai": "^5.20.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/types/jspdf.d.ts
+++ b/types/jspdf.d.ts
@@ -1,0 +1,2 @@
+declare module "jspdf"
+export {};


### PR DESCRIPTION
## Summary
- add PDF download button to save conversation and generated summary
- expose conversation and summary to controls component
- include jspdf dependency and type declaration

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c30a364f2c8331a428e4cb2aa5fdb2