### PR TITLE
feat: add PDF export for conversation

### DIFF
--- a/app/components/Controls.tsx
+++ b/app/components/Controls.tsx
@@ -1,10 +1,101 @@
 "use client"
 
+import { Message } from "@/app/components/MessageList"
+import jsPDF from "jspdf"
+
 type Props = {
   onClear: () => void
+  messages: Message[]
+  summary: string | null
 }
 
-export default function Controls({ onClear }: Props) {
+export default function Controls({ onClear, messages, summary }: Props) {
+  const handleDownload = () => {
+    if (!summary) return
+    const doc = new jsPDF()
+    const pageWidth = doc.internal.pageSize.getWidth()
+    const pageHeight = doc.internal.pageSize.getHeight()
+    const margin = 10
+    const maxBubbleWidth = 120
+    const lineHeight = 6
+    let y = margin
+
+    messages.forEach(msg => {
+      const textLines = doc.splitTextToSize(msg.content, maxBubbleWidth)
+      const textWidth = Math.max(...textLines.map(line => doc.getTextWidth(line)))
+      const bubbleWidth = textWidth + 10
+      const bubbleHeight = textLines.length * lineHeight + 4
+
+      if (y + bubbleHeight > pageHeight - margin) {
+        doc.addPage()
+        y = margin
+      }
+
+      let x = margin
+      let fill: [number, number, number] = [229, 231, 235]
+      let textColor: [number, number, number] = [31, 41, 55]
+      let draw: [number, number, number] | null = null
+
+      if (msg.role === "user") {
+        x = pageWidth - margin - bubbleWidth
+        fill = [59, 130, 246]
+        textColor = [255, 255, 255]
+      } else if (msg.role === "error") {
+        fill = [254, 226, 226]
+        textColor = [185, 28, 28]
+        draw = [252, 165, 165]
+      }
+
+      if (draw) doc.setDrawColor(...draw)
+      doc.setFillColor(...fill)
+      doc.setTextColor(...textColor)
+      doc.roundedRect(x, y, bubbleWidth, bubbleHeight, 5, 5, draw ? "FD" : "F")
+      doc.text(textLines, x + 5, y + lineHeight)
+      y += bubbleHeight + 4
+    })
+
+    doc.addPage()
+    y = margin
+    doc.setTextColor(0, 0, 0)
+    const lines = summary.split("\n")
+
+    lines.forEach(line => {
+      if (y > pageHeight - margin) {
+        doc.addPage()
+        y = margin
+      }
+
+      if (line.startsWith("# ")) {
+        doc.setFont("helvetica", "bold")
+        doc.setFontSize(16)
+        doc.text(line.slice(2), margin, y)
+        y += 8
+      } else if (line.startsWith("## ")) {
+        doc.setFont("helvetica", "bold")
+        doc.setFontSize(14)
+        doc.text(line.slice(3), margin, y)
+        y += 7
+      } else if (line.startsWith("- ")) {
+        doc.setFont("helvetica", "normal")
+        doc.setFontSize(12)
+        const bulletLines = doc.splitTextToSize(line.slice(2), pageWidth - margin * 2 - 6)
+        const formatted = bulletLines.map((l, i) => (i === 0 ? `• ${l}` : `  ${l}`))
+        doc.text(formatted, margin + 2, y)
+        y += bulletLines.length * lineHeight
+      } else if (line.trim() === "") {
+        y += lineHeight
+      } else {
+        doc.setFont("helvetica", "normal")
+        doc.setFontSize(12)
+        const paragraph = doc.splitTextToSize(line, pageWidth - margin * 2)
+        doc.text(paragraph, margin, y)
+        y += paragraph.length * lineHeight
+      }
+    })
+
+    doc.save("conversation.pdf")
+  }
+
   return (
     <div className="flex gap-3 justify-center">
       <button
@@ -13,6 +104,14 @@ export default function Controls({ onClear }: Props) {
       >
         Effacer la conversation
       </button>
+      {summary && (
+        <button
+          onClick={handleDownload}
+          className="rounded-2xl bg-blue-600 px-4 py-2 text-white shadow hover:bg-blue-700"
+        >
+          Télécharger le PDF
+        </button>
+      )}
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -158,25 +158,25 @@ export default function InterviewPage() {
         <div className="rounded-2xl shadow bg-green-50 text-green-900 border border-green-300 p-6">
           <ReactMarkdown
             components={{
-              h1: ({node, ...props}) => (
+              h1: ({ ...props }) => (
                 <h1
                   className="text-2xl font-bold text-green-800 mb-4 border-b pb-2"
                   {...props}
                 />
               ),
-              h2: ({node, ...props}) => (
+              h2: ({ ...props }) => (
                 <h2
                   className="text-xl font-semibold text-green-700 mt-4 mb-2"
                   {...props}
                 />
               ),
-              ul: ({node, ...props}) => (
+              ul: ({ ...props }) => (
                 <ul className="list-disc list-inside space-y-1" {...props} />
               ),
-              li: ({node, ...props}) => (
+              li: ({ ...props }) => (
                 <li className="leading-snug" {...props} />
               ),
-              p: ({node, ...props}) => (
+              p: ({ ...props }) => (
                 <p className="my-1 leading-relaxed" {...props} />
               ),
             }}
@@ -192,7 +192,7 @@ export default function InterviewPage() {
         }
         disabled={timerState !== "running"}
       />
-      <Controls onClear={handleClear} />
+      <Controls onClear={handleClear} messages={messages} summary={summary} />
     </main>
   )
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "openai": "^5.20.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/types/jspdf.d.ts
+++ b/types/jspdf.d.ts
@@ -1,0 +1,2 @@
+declare module "jspdf"
+export {};


### PR DESCRIPTION
## Summary
- add PDF download button to save conversation and generated summary
- expose conversation and summary to controls component
- include jspdf dependency and type declaration
- render conversation bubbles and markdown-style summary in exported PDF

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c30a364f2c8331a428e4cb2aa5fdb2