### PR TITLE
Fix SpeechRecognition init in Composer

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useRef, useState, useEffect } from "react"
 import type { Message } from "./MessageList"
 
 type Props = {
@@ -11,7 +11,22 @@ type Props = {
 export default function Composer({ onSend, disabled }: Props) {
   const [text, setText] = useState("")
   const [recording, setRecording] = useState(false)
-  const recognitionRef = useRef<SpeechRecognition | null>(null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const SpeechRecognitionClass =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).SpeechRecognition ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).webkitSpeechRecognition
+
+      if (SpeechRecognitionClass) {
+        recognitionRef.current = new SpeechRecognitionClass()
+      }
+    }
+  }, [])
 
   const handleSend = () => {
     if (!text.trim() || disabled) return


### PR DESCRIPTION
## Summary
- ensure SpeechRecognition is only instantiated on the client using useEffect and a ref

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Module not found: Can't resolve 'jspdf')*


------
https://chatgpt.com/codex/tasks/task_b_68c33221aee88331b0bbcba755f5c7a0