### PR TITLE
feat: add speech recognition types

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, no-var */
+// types/global.d.ts
+
+interface SpeechRecognition extends EventTarget {
+  start(): void;
+  stop(): void;
+  abort(): void;
+  lang: string;
+  interimResults: boolean;
+  onresult: ((event: any) => void) | null;
+  onerror: ((event: any) => void) | null;
+  onend: (() => void) | null;
+}
+
+declare var webkitSpeechRecognition: {
+  new (): SpeechRecognition;
+};
+
+declare var SpeechRecognition: {
+  new (): SpeechRecognition;
+};


### PR DESCRIPTION
## Summary
- add global type declarations for SpeechRecognition and webkitSpeechRecognition

## Testing
- `pnpm lint`
- `npx tsc --noEmit` *(fails: Cannot find module 'jspdf' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68c333203d588331a327a15de8d9f44b