### PR TITLE
Use ChatGPT text-to-speech for assistant replies

### DIFF
--- a/app/api/speech/route.ts
+++ b/app/api/speech/route.ts
@@ -1,0 +1,44 @@
+import OpenAI from "openai"
+
+export const runtime = "nodejs"
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+export async function POST(req: Request) {
+  if (!process.env.OPENAI_API_KEY) {
+    return new Response("OPENAI_API_KEY manquant côté serveur.", { status: 500 })
+  }
+
+  let text: string
+  try {
+    const body = await req.json()
+    text = (body.text || "").trim()
+  } catch {
+    return new Response("Corps de requête invalide (JSON).", { status: 400 })
+  }
+
+  if (!text) {
+    return new Response("Texte à convertir manquant.", { status: 400 })
+  }
+
+  try {
+    const speech = await client.audio.speech.create({
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      input: text,
+    })
+
+    const buffer = Buffer.from(await speech.arrayBuffer())
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "audio/mpeg",
+      },
+    })
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Échec de synthèse."
+    return new Response(`Erreur côté modèle: ${msg}`, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,12 +16,22 @@ export default function InterviewPage() {
   const [summaryLoading, setSummaryLoading] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
 
-  const speak = (text: string) => {
+  const speak = async (text: string) => {
     if (typeof window === "undefined" || !text) return
-    const utter = new SpeechSynthesisUtterance(text)
-    utter.lang = "fr-FR"
-    window.speechSynthesis.cancel()
-    window.speechSynthesis.speak(utter)
+    try {
+      const res = await fetch("/api/speech", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      })
+      if (!res.ok) return
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const audio = new Audio(url)
+      audio.play()
+    } catch (e) {
+      console.error("Erreur de synthèse vocale", e)
+    }
   }
 
   const handleSend = async (msg: Message) => {
@@ -81,7 +91,7 @@ export default function InterviewPage() {
         }
         done = readerDone
       }
-      speak(fullText)
+      await speak(fullText)
     } catch {
       setMessages(prev =>
         prev.map(m =>


### PR DESCRIPTION
## Summary
- replace browser speech synthesis with ChatGPT text-to-speech API
- add `/api/speech` endpoint to generate audio with `gpt-4o-mini-tts`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c3bef925b883319f58f35f91873b03