### PR TITLE
feat: support persona-specific voices

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 // app/api/chat/route.ts
 import OpenAI from "openai"
+import { PERSONAS, PersonaId } from "@/app/personas"
 
 export const runtime = "nodejs" // explicite : on reste côté Node
 
@@ -8,17 +9,8 @@ const client = new OpenAI({
 })
 
 type Body = {
-  persona?: "manager" | "coach" | "recadrage" | string
+  persona?: PersonaId | string
   lastUserMessage?: string
-}
-
-const PERSONA_PROMPTS: Record<string, string> = {
-  manager:
-    "Tu es un manager exigeant, très factuel et orienté résultats. Tu vas droit au but, tu demandes des indicateurs, des échéances et des engagements. Style: concis, challengeant, professionnel. Une ou deux questions maximum par réponse.",
-  coach:
-    "Tu es un coach bienveillant. Tu reformules brièvement, tu poses des questions ouvertes, tu aides à clarifier les objectifs et les émotions. Style: empathique, constructif, 2 à 4 phrases courtes, une question de relance.",
-  recadrage:
-    "Tu es un manager qui recadre fermement. Tu es direct, précis, et demandes un engagement clair, des conséquences et un plan d'action immédiat. Style: assertif, sans agressivité, 2 à 3 phrases, termine par une exigence concrète.",
 }
 
 export async function POST(req: Request) {
@@ -33,9 +25,9 @@ export async function POST(req: Request) {
     return new Response("Corps de requête invalide (JSON).", { status: 400 })
   }
 
-  const persona = (body.persona || "manager").toLowerCase()
+  const persona = (body.persona || "manager").toLowerCase() as PersonaId
   const lastUserMessage = (body.lastUserMessage || "").trim()
-  const systemPrompt = PERSONA_PROMPTS[persona] ?? PERSONA_PROMPTS.manager
+  const systemPrompt = PERSONAS[persona]?.prompt ?? PERSONAS.manager.prompt
   const privacyPrompt =
     "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Réponds uniquement sur la base des messages fournis dans cette conversation."
 

--- a/app/components/PersonaSelect.tsx
+++ b/app/components/PersonaSelect.tsx
@@ -1,27 +1,23 @@
 "use client"
 
-type Props = {
-  value: string
-  onChange: (val: string) => void
-}
+import { PERSONAS, PersonaId } from "@/app/personas"
 
-const personas = [
-  { id: "manager", label: "Manager exigeant" },
-  { id: "coach", label: "Coach bienveillant" },
-  { id: "recadrage", label: "Recadrage direct" },
-]
+type Props = {
+  value: PersonaId
+  onChange: (val: PersonaId) => void
+}
 
 export default function PersonaSelect({ value, onChange }: Props) {
   return (
     <div className="flex flex-col gap-2 p-4 rounded-2xl shadow bg-gray-50">
       <h2 className="text-lg font-semibold">Choisir une persona</h2>
       <div className="flex gap-3">
-        {personas.map(p => (
+        {Object.entries(PERSONAS).map(([id, p]) => (
           <button
-            key={p.id}
-            onClick={() => onChange(p.id)}
+            key={id}
+            onClick={() => onChange(id as PersonaId)}
             className={`rounded-2xl px-4 py-2 shadow font-medium ${
-              value === p.id
+              value === id
                 ? "bg-blue-600 text-white"
                 : "bg-gray-200 text-gray-700 hover:bg-gray-300"
             }`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,22 +7,23 @@ import Composer from "@/app/components/Composer"
 import Controls from "@/app/components/Controls"
 import { useState } from "react"
 import ReactMarkdown from "react-markdown"
+import { PERSONAS, PersonaId } from "@/app/personas"
 
 export default function InterviewPage() {
   const [messages, setMessages] = useState<Message[]>([])
-  const [persona, setPersona] = useState("manager")
+  const [persona, setPersona] = useState<PersonaId>("manager")
   const [timerState, setTimerState] = useState<"idle" | "running" | "finished">("idle")
   const [summaryGenerated, setSummaryGenerated] = useState(false)
   const [summaryLoading, setSummaryLoading] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
 
-  const speak = async (text: string) => {
+  const speak = async (text: string, personaId: PersonaId) => {
     if (typeof window === "undefined" || !text) return
     try {
       const res = await fetch("/api/speech", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ text, voice: PERSONAS[personaId].voice }),
       })
       if (!res.ok) return
       const blob = await res.blob()
@@ -91,7 +92,7 @@ export default function InterviewPage() {
         }
         done = readerDone
       }
-      await speak(fullText)
+      await speak(fullText, persona)
     } catch {
       setMessages(prev =>
         prev.map(m =>

--- a/app/personas.ts
+++ b/app/personas.ts
@@ -1,0 +1,23 @@
+export type PersonaId = "manager" | "coach" | "recadrage"
+
+export const PERSONAS: Record<PersonaId, { label: string; voice: string; prompt: string }> = {
+  manager: {
+    label: "Manager exigeant",
+    voice: "alloy",
+    prompt:
+      "Tu es un manager exigeant, très factuel et orienté résultats. Tu vas droit au but, tu demandes des indicateurs, des échéances et des engagements. Style: concis, challengeant, professionnel. Une ou deux questions maximum par réponse.",
+  },
+  coach: {
+    label: "Coach bienveillant",
+    voice: "verse",
+    prompt:
+      "Tu es un coach bienveillant. Tu reformules brièvement, tu poses des questions ouvertes, tu aides à clarifier les objectifs et les émotions. Style: empathique, constructif, 2 à 4 phrases courtes, une question de relance.",
+  },
+  recadrage: {
+    label: "Recadrage direct",
+    voice: "lumen",
+    prompt:
+      "Tu es un manager qui recadre fermement. Tu es direct, précis, et demandes un engagement clair, des conséquences et un plan d'action immédiat. Style: assertif, sans agressivité, 2 à 3 phrases, termine par une exigence concrète.",
+  },
+} as const
+


### PR DESCRIPTION
## Summary
- allow each persona to define its own voice and prompt
- send persona voice to speech synthesis endpoint
- centralize persona definitions and use them in chat API and UI

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c3c963c19483318035c8d8d2edaf9b