### PR TITLE
Start silence countdown after assistant finishes speaking

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -78,7 +78,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
         role: "user",
         content: transcript,
       })
-      resetSilenceTimer()
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
     }
     recognition.onerror = () => {
       setVoiceMode(false)
@@ -105,6 +105,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
   useEffect(() => {
     const handleSpeakingStart = () => {
       if (voiceModeRef.current) {
+        if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
         wasVoiceModeRef.current = true
         recognitionRef.current?.stop()
         setVoiceMode(false)


### PR DESCRIPTION
## Summary
- clear existing silence timer when assistant begins speaking or user sends new speech
- start 10-second countdown only after assistant finishes talking

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c3d1e81ba08331bbb4ff969f3608d7