### PR TITLE
Stop voice mode when timer stops

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -103,6 +103,12 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
   }, [])
 
   useEffect(() => {
+    if (disabled && voiceModeRef.current) {
+      stopVoiceMode()
+    }
+  }, [disabled, stopVoiceMode])
+
+  useEffect(() => {
     const handleSpeakingStart = () => {
       if (voiceModeRef.current) {
         if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)


### PR DESCRIPTION
## Summary
- stop voice recognition when composer disabled so assistant listens only while timer runs

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_68c3d631db908331ad5f0c4c82e92460