### PR TITLE
Relance reconnaissance vocale après absence de speech

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -80,8 +80,13 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
       })
       if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
     }
-    recognition.onerror = () => {
-      setVoiceMode(false)
+    recognition.onerror = event => {
+      if (event.error === "no-speech") {
+        setTimeout(() => recognition.start(), 100)
+        resetSilenceTimer()
+      } else {
+        setVoiceMode(false)
+      }
     }
     recognition.onend = () => {
       if (voiceModeRef.current) {


### PR DESCRIPTION
## Summary
- Restart speech recognition when `no-speech` errors occur to keep voice mode active
- Preserve existing behavior for other recognition errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c3d7123b6c8331925f7508805594d3