### PR TITLE
fix: handle no-speech errors without immediate restart

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -82,7 +82,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     }
     recognition.onerror = event => {
       if (event.error === "no-speech") {
-        setTimeout(() => recognition.start(), 100)
+        recognition.abort()
         resetSilenceTimer()
       } else {
         setVoiceMode(false)


### PR DESCRIPTION
## Summary
- handle no-speech errors by aborting speech recognition instead of immediate restart

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c3d927a4ac83319af89dff39e1cdbe