### PR TITLE
Reset silence timer on speech result

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -78,7 +78,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
         role: "user",
         content: transcript,
       })
-      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
+      resetSilenceTimer()
     }
     recognition.onerror = event => {
       if (event.error === "no-speech") {


### PR DESCRIPTION
## Summary
- reset silence detection timer whenever speech recognition yields a result

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c3dbd70bc08331a29ca83ddca0cf5a