### PR TITLE
feat: add continuous flag to speech recognition

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -7,6 +7,7 @@ interface SpeechRecognition extends EventTarget {
   abort(): void;
   lang: string;
   interimResults: boolean;
+  continuous: boolean;
   onresult: ((event: any) => void) | null;
   onerror: ((event: any) => void) | null;
   onend: (() => void) | null;


### PR DESCRIPTION
## Summary
- add missing `continuous` property to `SpeechRecognition` interface

## Testing
- `pnpm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c3e2256994833191785b6b6aeef347