### PR TITLE
Simplify audio setup in speak

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,11 +31,6 @@ export default function InterviewPage() {
       const blob = await res.blob()
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)
-      const audioContext = new AudioContext()
-      const analyser = audioContext.createAnalyser()
-      const source = audioContext.createMediaElementSource(audio)
-      source.connect(analyser)
-      analyser.connect(audioContext.destination)
       audio.addEventListener("play", () => {
         window.dispatchEvent(new Event("assistant-speaking-start"))
       })


### PR DESCRIPTION
## Summary
- remove redundant AudioContext and analyser creation in `speak`
- keep play/ended/pause events and attach analyser before playing audio

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit` *(fails: Cannot find module '@react-three/fiber' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68c3f6f94b5c833190c83d963569798b