### PR TITLE
fix: add GLTFLoader .js extension

### DIFF
--- a/app/components/Avatar.tsx
+++ b/app/components/Avatar.tsx
@@ -2,7 +2,7 @@
 
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { Canvas, useLoader } from '@react-three/fiber'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import * as THREE from 'three'
 
 export interface AvatarHandle {


### PR DESCRIPTION
## Summary
- fix GLTFLoader import in Avatar component to include `.js` extension

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c686ec31048331a6fbc8939205dd66