### PR TITLE
chore: add GLTFLoader type declaration

### DIFF
--- a/types/three-gltfloader.d.ts
+++ b/types/three-gltfloader.d.ts
@@ -1,0 +1,3 @@
+declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
+  export * from 'three/examples/jsm/loaders/GLTFLoader';
+}


### PR DESCRIPTION
## Summary
- add missing GLTFLoader type declaration

## Testing
- `vercel build` *(fails: command not found)*
- `npx vercel build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*
- `pnpm build` *(fails: Turbopack build failed: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c68ad6d3d88331bbd9774cc6c031c9