### PR TITLE
Handle premature audio end and close contexts

### DIFF
--- a/app/components/Avatar.tsx
+++ b/app/components/Avatar.tsx
@@ -89,7 +89,9 @@ const Avatar = forwardRef<AvatarHandle>((_props, ref) => {
     if (audioRef.current && playHandlerRef.current) {
       audioRef.current.removeEventListener('play', playHandlerRef.current)
     }
-    if (ctxRef.current) ctxRef.current.close()
+    if (ctxRef.current) {
+      void ctxRef.current.close()
+    }
     analyserRef.current = null
     dataRef.current = null
     ctxRef.current = null

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,9 +38,13 @@ export default function InterviewPage() {
         window.dispatchEvent(new Event("assistant-speaking-end"))
         audio.removeEventListener("ended", stopEvent)
         audio.removeEventListener("pause", stopEvent)
+        audio.removeEventListener("error", stopEvent)
+        audio.removeEventListener("abort", stopEvent)
       }
       audio.addEventListener("ended", stopEvent)
       audio.addEventListener("pause", stopEvent)
+      audio.addEventListener("error", stopEvent)
+      audio.addEventListener("abort", stopEvent)
       avatarRef.current?.attachAudioAnalyser(audio)
       audio.play()
     } catch (e) {


### PR DESCRIPTION
## Summary
- Close previous AudioContext when stopping the avatar analyser
- Attach audio stop handler to error and abort events to ensure cleanup

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7cc6e7e3883318fe3eec6d8ecd1a5