### PR TITLE
Ensure audio context resumes before playing audio

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,8 +45,10 @@ export default function InterviewPage() {
       audio.addEventListener("pause", stopEvent)
       audio.addEventListener("error", stopEvent)
       audio.addEventListener("abort", stopEvent)
-      avatarRef.current?.attachAudioAnalyser(audio)
-      audio.play()
+      await avatarRef.current?.attachAudioAnalyser(audio)
+      await audio.play().catch(e => {
+        console.error("Erreur lecture audio", e)
+      })
     } catch (e) {
       console.error("Erreur de synthèse vocale", e)
     }


### PR DESCRIPTION
## Summary
- resume and animate audio analyser before playback using cross-browser AudioContext
- await audio playback and handle errors in speak()

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c7cea61f3c83319b55b08fbb29b781