### PR TITLE
fix: limit audio stop events to ended/error

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,20 +31,20 @@ export default function InterviewPage() {
       const blob = await res.blob()
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)
+      let started = false
       audio.addEventListener("play", () => {
+        started = true
         window.dispatchEvent(new Event("assistant-speaking-start"))
       })
       const stopEvent = () => {
-        window.dispatchEvent(new Event("assistant-speaking-end"))
+        if (started) {
+          window.dispatchEvent(new Event("assistant-speaking-end"))
+        }
         audio.removeEventListener("ended", stopEvent)
-        audio.removeEventListener("pause", stopEvent)
         audio.removeEventListener("error", stopEvent)
-        audio.removeEventListener("abort", stopEvent)
       }
       audio.addEventListener("ended", stopEvent)
-      audio.addEventListener("pause", stopEvent)
       audio.addEventListener("error", stopEvent)
-      audio.addEventListener("abort", stopEvent)
       await avatarRef.current?.attachAudioAnalyser(audio)
       await audio.play().catch(e => {
         console.error("Erreur lecture audio", e)


### PR DESCRIPTION
## Summary
- track audio playback start to avoid premature end event
- remove pause/abort listeners, handling only `ended` and `error`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7cfbfee048331b4f8e5c7b1d7498a