### PR TITLE
docs: ajouter commentaires détaillés

### DIFF
--- a/app/api/chat-summary/route.ts
+++ b/app/api/chat-summary/route.ts
@@ -1,3 +1,4 @@
+// 🧾 Route API chargée de produire une synthèse structurée de la conversation.
 import OpenAI from "openai"
 
 const client = new OpenAI({
@@ -19,6 +20,7 @@ export async function POST(req: Request) {
       )
     }
 
+    // 🧑‍💼 On ne conserve que les messages utilisateur pour l'analyse.
     const userOnlyTranscript = transcript.filter(
       (msg: { role: string }) => msg.role === "user"
     )
@@ -33,6 +35,7 @@ export async function POST(req: Request) {
     const privacyPrompt =
       "Ne fais aucune référence à des informations concernant le propriétaire du compte ChatGPT ou son identité. Base ton analyse uniquement sur la transcription fournie."
 
+    // 🧠 Appel au modèle pour synthétiser la session en trois volets.
     const completion = await client.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0.5,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,6 @@
 // app/api/chat/route.ts
+// 🚀 Route API responsable du streaming de réponses de la persona IA.
+// Elle prépare les prompts contextuels et renvoie la sortie d'OpenAI en direct.
 import OpenAI from "openai"
 import { PERSONAS, PersonaId } from "@/app/personas"
 
@@ -14,6 +16,7 @@ type Body = {
 }
 
 export async function POST(req: Request) {
+  // 🔐 Sécurité : on vérifie la présence de la clé avant toute requête.
   if (!process.env.OPENAI_API_KEY) {
     return new Response("OPENAI_API_KEY manquant côté serveur.", { status: 500 })
   }
@@ -25,6 +28,7 @@ export async function POST(req: Request) {
     return new Response("Corps de requête invalide (JSON).", { status: 400 })
   }
 
+  // 🎭 Sélection de la persona et du message utilisateur à transmettre au modèle.
   const persona = (body.persona || "manager").toLowerCase() as PersonaId
   const lastUserMessage = (body.lastUserMessage || "").trim()
   const systemPrompt = PERSONAS[persona]?.prompt ?? PERSONAS.manager.prompt
@@ -50,7 +54,7 @@ Format attendu en sortie :
   }
 
   try {
-    // Lancement du stream OpenAI (SDK v4)
+    // 🔄 Lancement du stream OpenAI (SDK v4)
     const stream = await client.chat.completions.stream({
       model: "gpt-4o-mini",
       temperature: 0.6,
@@ -71,6 +75,7 @@ Format attendu en sortie :
 
     const encoder = new TextEncoder()
 
+    // 📡 On convertit le flux OpenAI en ReadableStream natif pour le client.
     const readable = new ReadableStream({
       async start(controller) {
         try {

--- a/app/api/speech/route.ts
+++ b/app/api/speech/route.ts
@@ -1,3 +1,4 @@
+// 🔊 Route API qui convertit le texte des réponses en audio (text-to-speech).
 import OpenAI from "openai"
 
 export const runtime = "nodejs"
@@ -36,12 +37,13 @@ export async function POST(req: Request) {
   }
 
   try {
-    // Construction d'un texte SSML pour moduler rythme, hauteur et style.
+    // 🎼 Construction d'un texte SSML pour moduler rythme, hauteur et style.
     let ssml = `<speak><prosody rate="${rate}" pitch="${pitch}">${text}</prosody></speak>`
     if (style) {
       ssml = `<speak><prosody rate="${rate}" pitch="${pitch}"><emphasis level="${style}">${text}</emphasis></prosody></speak>`
     }
 
+    // 🗣️ Appel au modèle de synthèse vocale adapté aux voix expressives.
     const speech = await client.audio.speech.create({
       model: "gpt-4o-mini-tts",
       voice,
@@ -50,6 +52,7 @@ export async function POST(req: Request) {
 
     const buffer = Buffer.from(await speech.arrayBuffer())
 
+    // 🔁 Renvoi du buffer audio directement dans la réponse HTTP.
     return new Response(buffer, {
       headers: {
         "Content-Type": "audio/mpeg",

--- a/app/components/Avatar.tsx
+++ b/app/components/Avatar.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+// 🧑‍🚀 Avatar 3D synchronisé avec la voix du modèle.
+// Ce composant charge un modèle glTF et anime ses morph targets en fonction
+// d'un analyseur audio Web Audio API pour simuler la parole.
 import {
   forwardRef,
   useEffect,
@@ -11,6 +14,7 @@ import { Canvas, useLoader } from '@react-three/fiber'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import * as THREE from 'three'
 
+// 🎛️ Méthodes exposées au parent pour connecter une source audio externe.
 export interface AvatarHandle {
   attachAudioAnalyser(audio: HTMLAudioElement): Promise<void>
 }
@@ -32,10 +36,12 @@ function AvatarModel({
 }: {
   mouthMeshesRef: MutableRefObject<MorphableMesh[]>
 }) {
+  // Chargement du modèle 3D animé (glTF) une seule fois.
   const gltf = useLoader(GLTFLoader, '/avatar.glb')
 
   useEffect(() => {
     mouthMeshesRef.current = []
+    // On parcourt la scène pour récupérer toutes les meshes contrôlant la bouche.
     gltf.scene.traverse(child => {
       const mesh = child as MorphableMesh
       if (mesh.morphTargetDictionary?.mouthOpen !== undefined) {
@@ -78,6 +84,7 @@ const Avatar = forwardRef<AvatarHandle, AvatarProps>((
     noiseThresholdRef.current = noiseThreshold
   }, [noiseThreshold])
 
+  // 🌀 Animation continue : calcul de l'ouverture de bouche en fonction du spectre audio.
   const animate = () => {
     if (
       analyserRef.current &&
@@ -119,6 +126,7 @@ const Avatar = forwardRef<AvatarHandle, AvatarProps>((
     rafRef.current = requestAnimationFrame(animate)
   }
 
+  // ⏹️ Arrête toute lecture et libère les ressources audio.
   const stop = () => {
     if (rafRef.current) {
       cancelAnimationFrame(rafRef.current)
@@ -143,6 +151,7 @@ const Avatar = forwardRef<AvatarHandle, AvatarProps>((
   }, [])
 
   useImperativeHandle(ref, () => ({
+    // 📡 Connexion d'un élément audio HTML : création d'un contexte et d'un analyseur.
     async attachAudioAnalyser(audio: HTMLAudioElement) {
       stop()
       const AudioCtx =

--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+// 📝 Zone de composition des messages utilisateur.
+// Gère aussi le mode dictée vocale et la détection de silences prolongés.
 import { useRef, useState, useEffect, useCallback } from "react"
 import type { Message } from "./MessageList"
 
@@ -18,6 +20,8 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
   const silenceTimerRef = useRef<NodeJS.Timeout | null>(null)
   const wasVoiceModeRef = useRef(false)
 
+  // 🌐 Au montage, on teste la disponibilité de l'API Web Speech et on stocke
+  // la classe de reconnaissance pour pouvoir l'instancier plus tard.
   useEffect(() => {
     if (typeof window !== "undefined") {
       const SpeechRecognitionClass =
@@ -36,6 +40,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     voiceModeRef.current = voiceMode
   }, [voiceMode])
 
+  // ✉️ Envoi manuel d'un message textuel classique.
   const handleSend = () => {
     if (!text.trim() || disabled) return
     onSend({
@@ -46,6 +51,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     setText("")
   }
 
+  // ⏱️ Relance automatique de l'IA après 10 secondes de silence en mode voix.
   const resetSilenceTimer = useCallback(() => {
     if (!voiceModeRef.current) return
     if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
@@ -55,6 +61,7 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     }, 10000)
   }, [onSilence])
 
+  // 🎙️ Active le mode reconnaissance vocale continue.
   const startVoiceMode = useCallback(() => {
     if (voiceModeRef.current || disabled) return
     const SpeechRecognition =
@@ -101,18 +108,22 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     resetSilenceTimer()
   }, [disabled, onSend, resetSilenceTimer])
 
+  // ⏹️ Arrête proprement la dictée vocale et le timer de silence.
   const stopVoiceMode = useCallback(() => {
     setVoiceMode(false)
     if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
     recognitionRef.current?.stop()
   }, [])
 
+  // Si l'utilisateur désactive l'envoi (timer arrêté), on coupe aussi la dictée.
   useEffect(() => {
     if (disabled && voiceModeRef.current) {
       stopVoiceMode()
     }
   }, [disabled, stopVoiceMode])
 
+  // 🔄 Suspension automatique de la dictée quand l'avatar parle pour éviter
+  // que la voix synthétique soit reconnue comme une entrée utilisateur.
   useEffect(() => {
     const handleSpeakingStart = () => {
       if (voiceModeRef.current) {

--- a/app/components/Controls.tsx
+++ b/app/components/Controls.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+// 🧾 Actions finales : remise à zéro de la conversation et export PDF.
 import { Message } from "@/app/components/MessageList"
 import jsPDF from "jspdf"
 
@@ -10,6 +11,7 @@ type Props = {
 }
 
 export default function Controls({ onClear, messages, summary }: Props) {
+  // 📥 Génère un PDF contenant l'historique et la synthèse finale.
   const handleDownload = () => {
     if (!summary || messages.length === 0) return
     const doc = new jsPDF()
@@ -19,6 +21,7 @@ export default function Controls({ onClear, messages, summary }: Props) {
     const lineHeight = 7
     let y = margin
 
+    // 🗨️ Dessine chaque bulle de message avec un code couleur par rôle.
     messages.forEach(msg => {
       const textLines = doc.splitTextToSize(
         msg.content,
@@ -61,6 +64,7 @@ export default function Controls({ onClear, messages, summary }: Props) {
       y += bubbleHeight + 4
     })
 
+    // 🧠 Ajout d'une nouvelle page pour la synthèse structurée.
     doc.addPage()
     doc.setFont("helvetica", "bold")
     doc.setFontSize(18)
@@ -110,6 +114,7 @@ export default function Controls({ onClear, messages, summary }: Props) {
 
   return (
     <div className="flex gap-3 justify-center">
+      {/* 🔁 Permet de relancer un nouvel entretien immédiatement. */}
       <button
         onClick={onClear}
         className="rounded-2xl bg-gray-300 px-4 py-2 text-gray-800 shadow hover:bg-gray-400"

--- a/app/components/MessageList.tsx
+++ b/app/components/MessageList.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+// 💬 Affichage des échanges sous forme de bulles colorées et scroll automatique.
 import { useEffect, useRef, ReactNode } from "react"
 
 export type Message = {
@@ -15,6 +16,7 @@ type Props = {
 export default function MessageList({ messages }: Props) {
   const endRef = useRef<HTMLDivElement | null>(null)
 
+  // 🎯 Scroll automatique vers le bas à chaque nouveau message.
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [messages])
@@ -25,6 +27,7 @@ export default function MessageList({ messages }: Props) {
         let bubbleStyle = ""
         let content: ReactNode = msg.content
 
+        // 🎨 Style conditionnel suivant l'émetteur du message.
         if (msg.role === "user") {
           bubbleStyle = "bg-blue-500 text-white self-end"
         } else if (msg.role === "assistant") {

--- a/app/components/PersonaSelect.tsx
+++ b/app/components/PersonaSelect.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+// 🎭 Permet de choisir la persona avec laquelle interagir.
 import { PERSONAS, PersonaId } from "@/app/personas"
 
 type Props = {
@@ -12,6 +13,7 @@ export default function PersonaSelect({ value, onChange }: Props) {
     <div className="flex flex-col gap-2 p-4 rounded-2xl shadow bg-gray-50">
       <h2 className="text-lg font-semibold">Choisir une persona</h2>
       <div className="flex gap-3">
+        {/* Boucle sur toutes les personas déclarées pour proposer des boutons */}
         {Object.entries(PERSONAS).map(([id, p]) => (
           <button
             key={id}

--- a/app/components/Timer.tsx
+++ b/app/components/Timer.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+// ⏱️ Chronomètre d'entretien : lance la session et déclenche la synthèse finale.
 import { useEffect, useState, useRef } from "react"
 
 type Props = {
@@ -12,12 +13,14 @@ export default function Timer({ onStateChange }: Props) {
   const [state, setState] = useState<"idle" | "running" | "finished">("idle")
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
+  // 🔢 Convertit les secondes restantes en format mm:ss lisible.
   const formatTime = (seconds: number) => {
     const m = Math.floor(seconds / 60).toString().padStart(2, "0")
     const s = Math.floor(seconds % 60).toString().padStart(2, "0")
     return `${m}:${s}`
   }
 
+  // ▶️ Lancement du décompte si le chrono n'est pas déjà en cours.
   const start = () => {
     if (state === "running") return
     setState("running")
@@ -34,11 +37,13 @@ export default function Timer({ onStateChange }: Props) {
     }, 1000)
   }
 
+  // ⏸️ Met immédiatement fin à la session en cours.
   const stop = () => {
     if (intervalRef.current) clearInterval(intervalRef.current)
     setState("finished")
   }
 
+  // 🔄 Réinitialise le timer pour une nouvelle tentative.
   const reset = () => {
     if (intervalRef.current) clearInterval(intervalRef.current)
     setRemaining(duration * 60)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,6 @@
+// 📄 Définition du layout racine de l'application Next.js.
+// Ce fichier englobe toutes les pages et applique la configuration globale
+// (polices, langue du document, styles partagés).
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -22,11 +25,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // 🌐 Structure HTML de base : on définit la langue et on injecte les polices
+  // déclarées plus haut pour toutes les pages.
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        {/* Toutes les pages seront rendues ici */}
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+// 🧭 Page principale de simulation d'entretien. Elle orchestre l'avatar,
+// la reconnaissance vocale, le minuteur et la génération des réponses IA.
 import PersonaSelect from "@/app/components/PersonaSelect"
 import Timer from "@/app/components/Timer"
 import MessageList, { Message } from "@/app/components/MessageList"
@@ -11,14 +13,18 @@ import ReactMarkdown from "react-markdown"
 import { PERSONAS, PersonaId } from "@/app/personas"
 
 export default function InterviewPage() {
+  // 💬 Historique de la conversation et état de la simulation
   const [messages, setMessages] = useState<Message[]>([])
   const [persona, setPersona] = useState<PersonaId>("manager")
   const [timerState, setTimerState] = useState<"idle" | "running" | "finished">("idle")
   const [summaryGenerated, setSummaryGenerated] = useState(false)
   const [summaryLoading, setSummaryLoading] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
+  // Référence vers l'avatar 3D pour lui attacher l'analyseur audio
   const avatarRef = useRef<AvatarHandle>(null)
 
+  // 🔊 Déclenche la synthèse vocale d'un texte généré par l'IA.
+  // On récupère un flux audio depuis notre API puis on le joue dans le navigateur.
   const speak = async (text: string, personaId: PersonaId) => {
     if (typeof window === "undefined" || !text) return
     try {
@@ -54,6 +60,9 @@ export default function InterviewPage() {
     }
   }
 
+  // ✉️ Envoi d'un message utilisateur et gestion du flux de réponse de l'IA.
+  // On ajoute d'abord le message dans l'historique puis on écoute la réponse
+  // en streaming pour l'afficher progressivement.
   const handleSend = async (msg: Message) => {
     if (timerState !== "running") return
 
@@ -127,6 +136,8 @@ export default function InterviewPage() {
     }
   }
 
+  // 🤫 Gestion d'un silence prolongé de l'utilisateur : on force l'IA
+  // à relancer la conversation pour maintenir le rythme de l'entretien.
   const handleSilence = async () => {
     if (timerState !== "running") return
 
@@ -199,7 +210,7 @@ export default function InterviewPage() {
     }
   }
 
-  // ✅ Génération de synthèse automatique
+  // ✅ Génération automatique de la synthèse finale dès que le timer se termine.
   const generateSummary = async () => {
     if (summaryGenerated || summaryLoading) return
     setSummaryLoading(true)
@@ -239,6 +250,7 @@ export default function InterviewPage() {
     }
   }
 
+  // 🧹 Réinitialisation complète de la session : conversation, minuteur et synthèse.
   const handleClear = () => {
     setMessages([])
     setTimerState("idle")
@@ -309,6 +321,7 @@ export default function InterviewPage() {
         onSilence={handleSilence}
         disabled={timerState !== "running"}
       />
+      {/* Boutons de reset et export PDF */}
       <Controls onClear={handleClear} messages={messages} summary={summary} />
     </main>
   )

--- a/app/personas.ts
+++ b/app/personas.ts
@@ -1,26 +1,32 @@
+// 🗂️ Catalogue des personas disponibles et de leurs prompts respectifs.
 export type PersonaId = "manager" | "client" | "collaborateur" | "conflit" | "prospect"
 
 export const PERSONAS: Record<PersonaId, { label: string; voice: string; prompt: string }> = {
+  // 👔 Manager pressant qui pousse à la performance immédiate.
   manager: {
     label: "Manager exigeant",
     voice: "sage",
     prompt: "Tu es un manager exigeant, pressé, qui veut des résultats immédiats. Pendant l’entretien : Interromps régulièrement, pose des questions incisives, Montre une certaine impatience, Remets en cause la pertinence des réponses de l’utilisateur. À la fin de la session, tu ne donnes pas de feedback : tu laisses l’analyse finale au module Analyse.",
   },
+  // 🧾 Client difficile à convaincre, toujours en quête de garanties.
   client: {
     label: "Client difficile",
     voice: "shimmer",
     prompt: "Tu es un client méfiant et difficile à convaincre. Pendant l’entretien : Mets en avant ton scepticisme, Soulève des objections constantes (prix, délais, confiance), Mets l’utilisateur face à des silences inconfortables. Reste dans ton rôle de client et n’évalue pas directement la performance.",
   },
+  // 🧑‍🤝‍🧑 Collaborateur démotivé nécessitant de la pédagogie.
   collaborateur: {
     label: "Collaborateur en difficulté",
     voice: "onyx",
     prompt: "Tu es un collaborateur en difficulté, démotivé et sur la défensive. Pendant l’entretien : Montre de la résistance passive, Réponds de manière évasive ou minimaliste, Exprime un malaise ou un découragement. Ne facilite pas la tâche à l’utilisateur, oblige-le à trouver des leviers de motivation.",
   },
+  // ⚡ Collègue en conflit ouvert qui cherche à régler ses comptes.
   conflit: {
     label: "Collègue en conflit",
     voice: "echo",
     prompt: "Tu es un collègue en colère, persuadé que l’utilisateur t’a manqué de respect. Pendant l’entretien : Adopte un ton accusateur, Rappelle un incident passé, Mets l’accent sur l’injustice ressentie. Garde un ton conflictuel tout au long de l’échange.",
   },
+  // 🤝 Prospect neutre à rassurer durant la prise de contact.
   prospect: {
     label: "Prospect neutre",
     voice: "echo",


### PR DESCRIPTION
## Summary
- documenter la page principale et les composants interactifs avec des commentaires explicatifs en français
- ajouter des commentaires pédagogiques dans les routes API et la configuration des personas pour clarifier les flux métiers

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68c921c99ea08331b66b4481c59fbfb4