### PR TITLE
Add commercial proposal for CoachVisio offers

### DIFF
--- a/docs/proposition-commerciale.md
+++ b/docs/proposition-commerciale.md
@@ -1,0 +1,71 @@
+# Proposition commerciale CoachVisio
+
+## 1. Présentation générale
+CoachVisio est une solution SaaS de simulation d'entretiens professionnels qui combine personas réalistes, analyse automatisée des performances et outils de suivi pour les responsables formation. Notre objectif est de permettre à vos équipes, apprenants ou clients de s'entraîner dans un environnement sécurisé et mesurable, afin d'améliorer durablement leurs compétences relationnelles et commerciales.
+
+## 2. Offre de valeur
+- **Expérience immersive** : scénarios audio/texte personnalisables pour s'entraîner à tout moment.
+- **Feedback actionnable** : synthèse automatique des forces, axes d'amélioration et recommandations.
+- **Pilotage de la performance** : tableau de bord par utilisateur, équipe ou promotion.
+- **Intégration fluide** : API, SSO et connecteurs LMS/ATS en option.
+
+## 3. Grille tarifaire (HT)
+| Offre | Utilisation / fonctionnalités incluses | Tarif mensuel | Positionnement |
+|-------|----------------------------------------|---------------|----------------|
+| **Starter** | 30 sessions audio/texte par utilisateur et par mois, 2 personas standards, feedback automatisé basique, accès à la base de scénarios, support communautaire | 19 € / utilisateur | Indépendants, étudiants, freelances | 
+| **Pro** | Sessions illimitées, 5 personas standards, personnalisation des scénarios, export PDF, intégration API, espace manager, support email sous 24 h ouvrées | 49 € / utilisateur | PME, cabinets de coaching, équipes commerciales | 
+| **Entreprise** | Sessions illimitées, personas sur mesure, analytics avancées, tableaux de bord multi-équipes, SSO, SLA 99,9 %, gestionnaire de compte dédié, audit de déploiement | À partir de 149 € / utilisateur (tarif dégressif selon volume) | Grandes entreprises, groupes internationaux |
+
+## 4. Options de personnalisation selon le type de client
+### 4.1 Indépendants et étudiants
+- Pack "Démarrage Express" : paramétrage guidé des scénarios principaux et recommandation de parcours de formation (forfait 250 €).
+- Certification CoachVisio : badge numérique attestant des compétences travaillées, exportable sur LinkedIn (49 € / participant).
+
+### 4.2 PME et cabinets de coaching
+- Bibliothèque sectorielle : accès à des scénarios adaptés (BTP, retail, conseil, IT) + 10 scénarios personnalisés (1 200 €).
+- Co-animation : possibilité d'intégrer vos coachs dans la plateforme (30 € / coach / mois) avec interface dédiée.
+
+### 4.3 Grandes entreprises et groupes internationaux
+- Projet pilote clé en main (6 à 8 semaines) comprenant ateliers de cadrage, création de personas internes, sessions de test et comité de pilotage (8 500 €).
+- Intégration avancée (API, SSO, SCORM) réalisée par nos experts (sur devis à partir de 4 000 €).
+- Hébergement dédié UE ou US selon votre politique de conformité.
+
+### 4.4 Écoles et universités
+- Mode "promotion" permettant de suivre les cohortes (inclus à partir de 200 licences).
+- Sessions collectives synchrones (jusqu'à 30 participants) avec scoring comparatif (500 € / événement).
+- Accès carrière : portail étudiant en marque blanche (2 500 € / an).
+
+### 4.5 Partenaires formation et cabinets RH
+- Offre white-label : personnalisation du branding, URL dédiée, supports marketing co-brandés (à partir de 5 000 € / an).
+- Programme revendeur : marge jusqu'à 20 % et accès à notre centre de ressources partenaires.
+
+## 5. Options complémentaires
+- **Coaching humain** : intervention d'un coach certifié pour relire les enregistrements et proposer un feedback personnalisé (80 € / session).
+- **Formation sur mesure** : ateliers présentiels ou visio animés par nos experts (1 000 € / jour).
+- **Pack data & analytics** : rapports trimestriels, benchmark sectoriel, recommandations d'amélioration (1 200 € / an).
+- **Support premium** : ligne directe et support 7j/7 pour les administrateurs (450 € / mois).
+
+## 6. Méthodologie de déploiement
+1. **Cadrage** : atelier de définition des objectifs, personas ciblés et indicateurs de succès.
+2. **Paramétrage** : configuration de l'environnement, import des utilisateurs et scénarios.
+3. **Onboarding** : sessions de formation administrateurs et ateliers utilisateurs.
+4. **Phase pilote** : période de 4 à 6 semaines pour mesurer l'adoption et ajuster les parcours.
+5. **Généralisation** : déploiement progressif, reporting régulier et accompagnement du changement.
+6. **Optimisation continue** : revues trimestrielles, mises à jour des contenus et des personas.
+
+## 7. Engagements de service
+- **Sécurité et conformité** : hébergement cloud européen, conformité RGPD, chiffrement des enregistrements audio.
+- **Disponibilité** : SLA jusqu'à 99,9 % sur l'offre Entreprise, monitoring 24/7.
+- **Support** : base de connaissances, support email (Pro), support dédié et accompagnement stratégique (Entreprise).
+- **Évolution produit** : roadmap partagée, nouvelles fonctionnalités livrées mensuellement.
+
+## 8. Conditions commerciales
+- Abonnement mensuel ou annuel (2 mois offerts pour tout engagement 12 mois).
+- Facturation centralisée et paiement par virement, prélèvement SEPA ou carte bancaire.
+- Possibilité de clause de réversibilité et restitution des données à la demande.
+- Validité de la présente offre : 60 jours à compter de l'émission.
+
+## 9. Prochaines étapes
+Nous vous proposons une session de démonstration personnalisée de 45 minutes pour valider vos cas d'usage prioritaires. À l'issue de cette session, nous co-construirons un calendrier de déploiement adapté à vos contraintes internes.
+
+Pour confirmer votre intérêt ou demander un devis personnalisé, contactez-nous à l'adresse **sales@coachvisio.com** ou au **+33 1 86 XX XX XX**. Nous restons à votre disposition pour toute question complémentaire.


### PR DESCRIPTION
## Summary
- add a French commercial proposal covering the Starter, Pro and Entreprise offers
- describe customization paths for multiple client segments and optional add-ons

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68c92bdeda888331b7d709cbb21d9f70