### PR TITLE
Enhance persona selection with avatars and timer

### DIFF
--- a/app/components/PersonaSelect.tsx
+++ b/app/components/PersonaSelect.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 // 🎭 Permet de choisir la persona avec laquelle interagir.
+import Image from "next/image"
+import RemainingTime from "@/app/components/RemainingTime"
 import { PERSONAS, PersonaId } from "@/app/personas"
 
 type Props = {
@@ -10,27 +12,52 @@ type Props = {
 
 export default function PersonaSelect({ value, onChange }: Props) {
   return (
-    <div className="flex flex-col gap-2 p-4 rounded-2xl shadow bg-gray-50">
-      <h2 className="text-lg font-semibold">Choisir une persona</h2>
-      <div className="flex gap-3">
-        {/* Boucle sur toutes les personas déclarées pour proposer des boutons */}
-        {Object.entries(PERSONAS).map(([id, p]) => (
-          <button
-            key={id}
-            onClick={() => onChange(id as PersonaId)}
-            className={`rounded-2xl px-4 py-2 shadow font-medium ${
-              value === id
-                ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300"
-            }`}
-          >
-            {p.label}
-          </button>
-        ))}
+    <section className="flex flex-col gap-6 rounded-2xl bg-gray-50 p-6 shadow">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Choisir une persona</h2>
+        <RemainingTime />
       </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {/* Boucle sur toutes les personas déclarées pour proposer des cartes */}
+        {Object.entries(PERSONAS).map(([id, p]) => {
+          const isActive = value === id
+          return (
+            <button
+              type="button"
+              key={id}
+              onClick={() => onChange(id as PersonaId)}
+              aria-pressed={isActive}
+              className={`group relative flex w-full items-center gap-4 rounded-2xl border bg-white/90 p-4 text-left shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                isActive
+                  ? "border-blue-500 bg-white shadow-md ring-2 ring-blue-200"
+                  : "border-transparent hover:border-blue-200 hover:bg-white"
+              }`}
+            >
+              <span className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/60 bg-blue-50 shadow-inner">
+                <Image
+                  src={p.avatar}
+                  alt={`Avatar ${p.label}`}
+                  width={64}
+                  height={64}
+                  className="h-full w-full object-cover"
+                  sizes="64px"
+                />
+              </span>
+              <span className="flex flex-col">
+                <span className="text-base font-semibold text-gray-900">{p.label}</span>
+                <span className="text-sm text-gray-600">{p.role}</span>
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
       <p className="text-sm text-gray-600">
-        Persona active : <span className="font-bold">{value}</span>
+        Persona active :{" "}
+        <span className="font-semibold text-gray-900">{PERSONAS[value].label}</span>
+        <span className="text-gray-400"> · {PERSONAS[value].role}</span>
       </p>
-    </div>
+    </section>
   )
 }

--- a/app/components/RemainingTime.tsx
+++ b/app/components/RemainingTime.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+// ⏳ Affiche le temps de session restant (60 minutes à partir de la connexion).
+import { useEffect, useState } from "react"
+
+const SESSION_DURATION_MS = 60 * 60 * 1000
+const STORAGE_KEY = "coachvisio-login-timestamp"
+
+const formatTime = (milliseconds: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(milliseconds / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes.toString().padStart(2, "0")}:${seconds
+    .toString()
+    .padStart(2, "0")}`
+}
+
+export default function RemainingTime() {
+  const [remainingMs, setRemainingMs] = useState(SESSION_DURATION_MS)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const now = Date.now()
+    const stored = Number(window.localStorage.getItem(STORAGE_KEY))
+    let loginTimestamp = Number.isFinite(stored) ? stored : now
+
+    if (now - loginTimestamp >= SESSION_DURATION_MS || !Number.isFinite(stored)) {
+      loginTimestamp = now
+      window.localStorage.setItem(STORAGE_KEY, String(loginTimestamp))
+    }
+
+    let intervalId: number | null = null
+
+    const updateRemaining = () => {
+      const elapsed = Date.now() - loginTimestamp
+      const remaining = Math.max(0, SESSION_DURATION_MS - elapsed)
+      setRemainingMs(remaining)
+      if (remaining === 0 && intervalId !== null) {
+        window.clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+
+    updateRemaining()
+    intervalId = window.setInterval(updateRemaining, 1000)
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && event.newValue) {
+        const refreshed = Number(event.newValue)
+        if (Number.isFinite(refreshed)) {
+          loginTimestamp = refreshed
+          updateRemaining()
+        }
+      }
+    }
+
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.removeEventListener("storage", handleStorage)
+      if (intervalId !== null) {
+        window.clearInterval(intervalId)
+      }
+    }
+  }, [])
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-2xl border border-blue-200 bg-white/80 px-3 py-2 text-sm font-medium text-blue-700 shadow-sm">
+      <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-blue-500" aria-hidden="true" />
+      <span>
+        Temps restant session : <span className="font-semibold">{formatTime(remainingMs)}</span>
+      </span>
+    </div>
+  )
+}

--- a/app/personas.ts
+++ b/app/personas.ts
@@ -1,36 +1,54 @@
 // 🗂️ Catalogue des personas disponibles et de leurs prompts respectifs.
 export type PersonaId = "manager" | "client" | "collaborateur" | "conflit" | "prospect"
 
-export const PERSONAS: Record<PersonaId, { label: string; voice: string; prompt: string }> = {
+export type PersonaConfig = {
+  label: string
+  role: string
+  voice: string
+  prompt: string
+  avatar: string
+}
+
+export const PERSONAS = {
   // 👔 Manager pressant qui pousse à la performance immédiate.
   manager: {
     label: "Manager exigeant",
+    role: "Manager opérationnel",
     voice: "sage",
     prompt: "Tu es un manager exigeant, pressé, qui veut des résultats immédiats. Pendant l’entretien : Interromps régulièrement, pose des questions incisives, Montre une certaine impatience, Remets en cause la pertinence des réponses de l’utilisateur. À la fin de la session, tu ne donnes pas de feedback : tu laisses l’analyse finale au module Analyse.",
+    avatar: "/personas/manager.svg",
   },
   // 🧾 Client difficile à convaincre, toujours en quête de garanties.
   client: {
     label: "Client difficile",
+    role: "Client grand compte",
     voice: "shimmer",
     prompt: "Tu es un client méfiant et difficile à convaincre. Pendant l’entretien : Mets en avant ton scepticisme, Soulève des objections constantes (prix, délais, confiance), Mets l’utilisateur face à des silences inconfortables. Reste dans ton rôle de client et n’évalue pas directement la performance.",
+    avatar: "/personas/client.svg",
   },
   // 🧑‍🤝‍🧑 Collaborateur démotivé nécessitant de la pédagogie.
   collaborateur: {
     label: "Collaborateur en difficulté",
+    role: "Collègue à coacher",
     voice: "onyx",
     prompt: "Tu es un collaborateur en difficulté, démotivé et sur la défensive. Pendant l’entretien : Montre de la résistance passive, Réponds de manière évasive ou minimaliste, Exprime un malaise ou un découragement. Ne facilite pas la tâche à l’utilisateur, oblige-le à trouver des leviers de motivation.",
+    avatar: "/personas/collaborateur.svg",
   },
   // ⚡ Collègue en conflit ouvert qui cherche à régler ses comptes.
   conflit: {
     label: "Collègue en conflit",
+    role: "Pair en désaccord",
     voice: "echo",
     prompt: "Tu es un collègue en colère, persuadé que l’utilisateur t’a manqué de respect. Pendant l’entretien : Adopte un ton accusateur, Rappelle un incident passé, Mets l’accent sur l’injustice ressentie. Garde un ton conflictuel tout au long de l’échange.",
+    avatar: "/personas/conflit.svg",
   },
   // 🤝 Prospect neutre à rassurer durant la prise de contact.
   prospect: {
     label: "Prospect neutre",
+    role: "Premier contact",
     voice: "echo",
     prompt: "Tu es un prospect neutre, curieux mais réservé. Pendant l’entretien : Pose quelques questions simples, Montre de l’intérêt mais aussi de la prudence, Ne cherche pas à piéger l’utilisateur.",
+    avatar: "/personas/prospect.svg",
   }
-} as const
+} as const satisfies Record<PersonaId, PersonaConfig>
 

--- a/public/personas/client.svg
+++ b/public/personas/client.svg
@@ -1,0 +1,18 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradientClient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#5eead4" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#gradientClient)" />
+  <circle cx="80" cy="80" r="56" fill="#ffffff" fill-opacity="0.88" />
+  <text
+    x="80"
+    y="88"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-size="60"
+    font-family="'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif"
+  >🧾</text>
+</svg>

--- a/public/personas/collaborateur.svg
+++ b/public/personas/collaborateur.svg
@@ -1,0 +1,18 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradientCollaborateur" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#b45309" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#gradientCollaborateur)" />
+  <circle cx="80" cy="80" r="56" fill="#ffffff" fill-opacity="0.88" />
+  <text
+    x="80"
+    y="88"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-size="60"
+    font-family="'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif"
+  >🤝</text>
+</svg>

--- a/public/personas/conflit.svg
+++ b/public/personas/conflit.svg
@@ -1,0 +1,18 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradientConflit" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#b91c1c" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#gradientConflit)" />
+  <circle cx="80" cy="80" r="56" fill="#ffffff" fill-opacity="0.88" />
+  <text
+    x="80"
+    y="88"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-size="60"
+    font-family="'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif"
+  >⚡</text>
+</svg>

--- a/public/personas/manager.svg
+++ b/public/personas/manager.svg
@@ -1,0 +1,18 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradientManager" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#gradientManager)" />
+  <circle cx="80" cy="80" r="56" fill="#ffffff" fill-opacity="0.88" />
+  <text
+    x="80"
+    y="88"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-size="64"
+    font-family="'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif"
+  >👔</text>
+</svg>

--- a/public/personas/prospect.svg
+++ b/public/personas/prospect.svg
@@ -1,0 +1,18 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradientProspect" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6d28d9" />
+      <stop offset="100%" stop-color="#c084fc" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#gradientProspect)" />
+  <circle cx="80" cy="80" r="56" fill="#ffffff" fill-opacity="0.88" />
+  <text
+    x="80"
+    y="88"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-size="60"
+    font-family="'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif"
+  >📞</text>
+</svg>


### PR DESCRIPTION
## Summary
- enrich the persona catalogue with role labels and avatar paths
- replace the persona selector buttons with a grid of visual cards and display the remaining session time
- add a reusable RemainingTime widget and SVG avatar assets for each persona

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68c985d6d780833188361812a7a4b2f2