### PR TITLE
Ajoute les scénarios de personas et leur page dédiée

### DIFF
--- a/app/components/InterviewPageClient.tsx
+++ b/app/components/InterviewPageClient.tsx
@@ -8,20 +8,40 @@ import MessageList, { Message } from "@/app/components/MessageList"
 import Composer from "@/app/components/Composer"
 import Controls from "@/app/components/Controls"
 import Avatar, { AvatarHandle } from "@/app/components/Avatar"
-import { useState, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
+import { useSearchParams } from "next/navigation"
 import ReactMarkdown from "react-markdown"
-import { PERSONAS, PersonaId } from "@/app/personas"
+import { PERSONAS, PersonaId, isPersonaId } from "@/app/personas"
 
 export default function InterviewPageClient() {
   // 💬 Historique de la conversation et état de la simulation
   const [messages, setMessages] = useState<Message[]>([])
-  const [persona, setPersona] = useState<PersonaId>("manager")
+  const searchParams = useSearchParams()
+  const personaFromQuery = searchParams.get("persona")
+  const [persona, setPersona] = useState<PersonaId>(() =>
+    isPersonaId(personaFromQuery) ? personaFromQuery : "manager"
+  )
   const [timerState, setTimerState] = useState<"idle" | "running" | "finished">("idle")
   const [summaryGenerated, setSummaryGenerated] = useState(false)
   const [summaryLoading, setSummaryLoading] = useState(false)
   const [summary, setSummary] = useState<string | null>(null)
+  const lastPersonaFromQuery = useRef<string | null>(personaFromQuery)
   // Référence vers l'avatar 3D pour lui attacher l'analyseur audio
   const avatarRef = useRef<AvatarHandle>(null)
+
+  useEffect(() => {
+    if (lastPersonaFromQuery.current === personaFromQuery) {
+      return
+    }
+
+    lastPersonaFromQuery.current = personaFromQuery
+
+    if (isPersonaId(personaFromQuery)) {
+      setPersona(personaFromQuery)
+    } else {
+      setPersona("manager")
+    }
+  }, [personaFromQuery])
 
   // 🔊 Déclenche la synthèse vocale d'un texte généré par l'IA.
   // On récupère un flux audio depuis notre API puis on le joue dans le navigateur.

--- a/app/personas.ts
+++ b/app/personas.ts
@@ -4,6 +4,7 @@ export type PersonaId = "manager" | "client" | "collaborateur" | "conflit" | "pr
 export type PersonaConfig = {
   label: string
   role: string
+  scenario: string
   voice: string
   prompt: string
   avatar: string
@@ -14,6 +15,8 @@ export const PERSONAS = {
   manager: {
     label: "Manager exigeant",
     role: "Manager opérationnel",
+    scenario:
+      "Contexte : réunion de suivi sur un projet critique qui prend du retard.\nObjectifs : rassurer le manager sur ta maîtrise, proposer un plan d'action concret et négocier des priorités réalistes sans perdre sa confiance.",
     voice: "sage",
     prompt: "Tu es un manager exigeant, pressé, qui veut des résultats immédiats. Pendant l’entretien : Interromps régulièrement, pose des questions incisives, Montre une certaine impatience, Remets en cause la pertinence des réponses de l’utilisateur. À la fin de la session, tu ne donnes pas de feedback : tu laisses l’analyse finale au module Analyse.",
     avatar: "/personas/manager.svg",
@@ -22,6 +25,8 @@ export const PERSONAS = {
   client: {
     label: "Client difficile",
     role: "Client grand compte",
+    scenario:
+      "Contexte : présentation d'une offre à un client qui hésite à signer.\nObjectifs : lever ses objections majeures, apporter des garanties concrètes sur la valeur et obtenir un engagement clair sur la suite.",
     voice: "shimmer",
     prompt: "Tu es un client méfiant et difficile à convaincre. Pendant l’entretien : Mets en avant ton scepticisme, Soulève des objections constantes (prix, délais, confiance), Mets l’utilisateur face à des silences inconfortables. Reste dans ton rôle de client et n’évalue pas directement la performance.",
     avatar: "/personas/client.svg",
@@ -30,6 +35,8 @@ export const PERSONAS = {
   collaborateur: {
     label: "Collaborateur en difficulté",
     role: "Collègue à coacher",
+    scenario:
+      "Contexte : entretien de recadrage avec un collaborateur démotivé après plusieurs erreurs.\nObjectifs : comprendre les causes de sa démotivation, fixer un cap réaliste de progression et l'amener à s'engager sur des actions.",
     voice: "onyx",
     prompt: "Tu es un collaborateur en difficulté, démotivé et sur la défensive. Pendant l’entretien : Montre de la résistance passive, Réponds de manière évasive ou minimaliste, Exprime un malaise ou un découragement. Ne facilite pas la tâche à l’utilisateur, oblige-le à trouver des leviers de motivation.",
     avatar: "/personas/collaborateur.svg",
@@ -38,6 +45,8 @@ export const PERSONAS = {
   conflit: {
     label: "Collègue en conflit",
     role: "Pair en désaccord",
+    scenario:
+      "Contexte : point de clarification après un conflit ouvert sur un projet commun.\nObjectifs : reconnaître les tensions sans t'excuser à outrance, rétablir une base de collaboration et définir des règles de fonctionnement partagées.",
     voice: "echo",
     prompt: "Tu es un collègue en colère, persuadé que l’utilisateur t’a manqué de respect. Pendant l’entretien : Adopte un ton accusateur, Rappelle un incident passé, Mets l’accent sur l’injustice ressentie. Garde un ton conflictuel tout au long de l’échange.",
     avatar: "/personas/conflit.svg",
@@ -46,9 +55,14 @@ export const PERSONAS = {
   prospect: {
     label: "Prospect neutre",
     role: "Premier contact",
+    scenario:
+      "Contexte : premier échange de qualification avec un prospect curieux mais prudent.\nObjectifs : instaurer la confiance, comprendre ses besoins clés et proposer un prochain pas concret.",
     voice: "echo",
     prompt: "Tu es un prospect neutre, curieux mais réservé. Pendant l’entretien : Pose quelques questions simples, Montre de l’intérêt mais aussi de la prudence, Ne cherche pas à piéger l’utilisateur.",
     avatar: "/personas/prospect.svg",
   }
 } as const satisfies Record<PersonaId, PersonaConfig>
+
+export const isPersonaId = (value: string | null): value is PersonaId =>
+  typeof value === "string" && value in PERSONAS
 

--- a/app/personas/[id]/page.tsx
+++ b/app/personas/[id]/page.tsx
@@ -1,0 +1,54 @@
+import Image from "next/image"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+
+import { PERSONAS, isPersonaId } from "@/app/personas"
+
+type PersonaPageProps = {
+  params: { id: string }
+}
+
+export default function PersonaPage({ params }: PersonaPageProps) {
+  const { id } = params
+
+  if (!isPersonaId(id)) {
+    notFound()
+  }
+
+  const persona = PERSONAS[id]
+
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <article className="flex flex-col gap-6 rounded-2xl bg-white p-6 shadow">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+          <span className="flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-gray-100 bg-blue-50 shadow-inner">
+            <Image
+              src={persona.avatar}
+              alt={`Avatar ${persona.label}`}
+              width={96}
+              height={96}
+              className="h-full w-full object-cover"
+              sizes="96px"
+            />
+          </span>
+          <div className="flex flex-col">
+            <h1 className="text-2xl font-bold text-gray-900">{persona.label}</h1>
+            <p className="text-sm text-gray-600">{persona.role}</p>
+          </div>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-gray-900">Objectif de la simulation</h2>
+          <p className="whitespace-pre-line text-gray-700">{persona.scenario}</p>
+        </section>
+
+        <Link
+          href={`/?persona=${id}`}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-base font-semibold text-white shadow transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          Démarrer la simulation
+        </Link>
+      </article>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- ajoute un champ de scénario aux personas pour expliciter les objectifs de chaque simulation
- crée la page `/personas/[id]` qui présente avatar, rôle et scénario avec un bouton pour démarrer la simulation
- initialise la simulation sur la persona transmise via le paramètre `persona` de l’URL

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68c98aeffb848331a53f56d50e3de8f9