### PR TITLE
Fix timer duration and deduct session allowance

### DIFF
--- a/app/components/InterviewPageClient.tsx
+++ b/app/components/InterviewPageClient.tsx
@@ -8,6 +8,7 @@ import MessageList, { Message } from "@/app/components/MessageList"
 import Composer from "@/app/components/Composer"
 import Controls from "@/app/components/Controls"
 import Avatar, { AvatarHandle } from "@/app/components/Avatar"
+import { useSessionTime } from "@/app/context/SessionTimeContext"
 import { useEffect, useRef, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import ReactMarkdown from "react-markdown"
@@ -28,6 +29,7 @@ export default function InterviewPageClient() {
   const lastPersonaFromQuery = useRef<string | null>(personaFromQuery)
   // Référence vers l'avatar 3D pour lui attacher l'analyseur audio
   const avatarRef = useRef<AvatarHandle>(null)
+  const { deductTime } = useSessionTime()
 
   useEffect(() => {
     if (lastPersonaFromQuery.current === personaFromQuery) {
@@ -286,6 +288,9 @@ export default function InterviewPageClient() {
           if (state === "finished") {
             generateSummary()
           }
+        }}
+        onStop={(elapsedSeconds) => {
+          deductTime(elapsedSeconds * 1000)
         }}
       />
       <div className="w-128 h-128" style={{ position: "relative", top: 0, left: 96 }}>

--- a/app/components/Timer.tsx
+++ b/app/components/Timer.tsx
@@ -1,80 +1,148 @@
 "use client"
 
-// ⏱️ Chronomètre d'entretien : lance la session et déclenche la synthèse finale.
-import { useEffect, useState, useRef } from "react"
+// ⏱️ Chronomètre d'entretien : lance la session, calcule le temps réel écoulé
+// et déclenche la synthèse finale lorsque la session se termine.
+import { useCallback, useEffect, useRef, useState } from "react"
+
+type TimerState = "idle" | "running" | "finished"
 
 type Props = {
-  onStateChange?: (state: "idle" | "running" | "finished") => void
+  onStateChange?: (state: TimerState) => void
+  onStop?: (elapsedSeconds: number) => void
 }
 
-export default function Timer({ onStateChange }: Props) {
-  const [duration, setDuration] = useState(5) // minutes
-  const [remaining, setRemaining] = useState(duration * 60) // secondes
-  const [state, setState] = useState<"idle" | "running" | "finished">("idle")
+const DURATION_MINUTES = 10
+const DURATION_SECONDS = DURATION_MINUTES * 60
+
+export default function Timer({ onStateChange, onStop }: Props) {
+  const [remaining, setRemaining] = useState(DURATION_SECONDS)
+  const [state, setState] = useState<TimerState>("idle")
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const startTimestampRef = useRef<number | null>(null)
+  const lastElapsedRef = useRef(0)
+  const stateRef = useRef<TimerState>(state)
 
-  // 🔢 Convertit les secondes restantes en format mm:ss lisible.
-  const formatTime = (seconds: number) => {
-    const m = Math.floor(seconds / 60).toString().padStart(2, "0")
-    const s = Math.floor(seconds % 60).toString().padStart(2, "0")
-    return `${m}:${s}`
-  }
-
-  // ▶️ Lancement du décompte si le chrono n'est pas déjà en cours.
-  const start = () => {
-    if (state === "running") return
-    setState("running")
-    intervalRef.current = setInterval(() => {
-      setRemaining(prev => {
-        if (prev <= 1) {
-          clearInterval(intervalRef.current!)
-          setState("finished") // fin du chrono
-          setRemaining(0)
-          return 0
-        }
-        return prev - 1
-      })
-    }, 1000)
-  }
-
-  // ⏸️ Met immédiatement fin à la session en cours.
-  const stop = () => {
-    if (intervalRef.current) clearInterval(intervalRef.current)
-    setState("finished")
-  }
-
-  // 🔄 Réinitialise le timer pour une nouvelle tentative.
-  const reset = () => {
-    if (intervalRef.current) clearInterval(intervalRef.current)
-    setRemaining(duration * 60)
-    setState("idle")
-  }
-
-  // Notifie le parent proprement à chaque changement d’état
   useEffect(() => {
+    stateRef.current = state
     onStateChange?.(state)
   }, [state, onStateChange])
 
-  // Quand on change la durée, on reset automatiquement
   useEffect(() => {
-    reset()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [duration])
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+      }
+    }
+  }, [])
+
+  const stopInternal = useCallback(
+    (completed: boolean) => {
+      if (stateRef.current !== "running") return
+
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+
+      let elapsedSeconds: number
+      if (completed) {
+        elapsedSeconds = DURATION_SECONDS
+      } else if (startTimestampRef.current != null) {
+        elapsedSeconds = Math.min(
+          DURATION_SECONDS,
+          Math.max(0, (Date.now() - startTimestampRef.current) / 1000),
+        )
+      } else {
+        elapsedSeconds = Math.min(DURATION_SECONDS, lastElapsedRef.current)
+      }
+
+      const remainingAfterStop = completed
+        ? 0
+        : Math.max(0, Math.ceil(DURATION_SECONDS - elapsedSeconds))
+
+      lastElapsedRef.current = elapsedSeconds
+      startTimestampRef.current = null
+
+      setRemaining(remainingAfterStop)
+      stateRef.current = "finished"
+      setState("finished")
+      onStop?.(elapsedSeconds)
+    },
+    [onStop],
+  )
+
+  const start = useCallback(() => {
+    if (stateRef.current === "running") return
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+
+    startTimestampRef.current = Date.now()
+    lastElapsedRef.current = 0
+    setRemaining(DURATION_SECONDS)
+    stateRef.current = "running"
+    setState("running")
+
+    const update = () => {
+      if (startTimestampRef.current == null) return
+
+      const elapsedSeconds = Math.min(
+        DURATION_SECONDS,
+        Math.max(0, (Date.now() - startTimestampRef.current) / 1000),
+      )
+      lastElapsedRef.current = elapsedSeconds
+
+      const nextRemaining = Math.max(
+        0,
+        Math.ceil(DURATION_SECONDS - elapsedSeconds),
+      )
+
+      setRemaining(nextRemaining)
+
+      if (nextRemaining === 0) {
+        stopInternal(true)
+      }
+    }
+
+    update()
+    intervalRef.current = setInterval(update, 250)
+  }, [stopInternal])
+
+  const stop = useCallback(() => {
+    stopInternal(false)
+  }, [stopInternal])
+
+  const reset = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    startTimestampRef.current = null
+    lastElapsedRef.current = 0
+    stateRef.current = "idle"
+    setState("idle")
+    setRemaining(DURATION_SECONDS)
+  }, [])
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, "0")
+    const s = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, "0")
+    return `${m}:${s}`
+  }
 
   return (
-    <div className="flex flex-col gap-3 p-4 rounded-2xl shadow bg-gray-50">
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-gray-600">Durée (minutes):</label>
-        <input
-          type="number"
-          min={1}
-          value={duration}
-          onChange={e => setDuration(Number(e.target.value))}
-          className="w-16 rounded border px-2 py-1 text-center"
-        />
+    <div className="flex flex-col gap-3 rounded-2xl bg-gray-50 p-4 shadow">
+      <div className="text-center text-sm text-gray-600">
+        Durée fixe : {DURATION_MINUTES} minutes
       </div>
 
-      <div className="text-3xl font-mono text-center">{formatTime(remaining)}</div>
+      <div className="text-center font-mono text-3xl">{formatTime(remaining)}</div>
 
       <div className="flex justify-center gap-2">
         <button

--- a/app/context/SessionTimeContext.tsx
+++ b/app/context/SessionTimeContext.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+
+const SESSION_DURATION_MS = 60 * 60 * 1000
+const STORAGE_KEY = "coachvisio-session-remaining"
+
+type SessionTimeContextValue = {
+  remainingMs: number
+  deductTime: (milliseconds: number) => void
+  reset: () => void
+}
+
+const SessionTimeContext = createContext<SessionTimeContextValue | undefined>(
+  undefined,
+)
+
+type SessionTimeProviderProps = {
+  children: ReactNode
+}
+
+export function SessionTimeProvider({ children }: SessionTimeProviderProps) {
+  const [remainingMs, setRemainingMs] = useState(SESSION_DURATION_MS)
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored !== null) {
+      const parsed = Number(stored)
+      if (Number.isFinite(parsed)) {
+        setRemainingMs(
+          Math.min(SESSION_DURATION_MS, Math.max(0, Math.round(parsed))),
+        )
+      }
+    }
+
+    setIsReady(true)
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && event.newValue != null) {
+        const parsed = Number(event.newValue)
+        if (Number.isFinite(parsed)) {
+          setRemainingMs(
+            Math.min(SESSION_DURATION_MS, Math.max(0, Math.round(parsed))),
+          )
+        }
+      }
+    }
+
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.removeEventListener("storage", handleStorage)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isReady || typeof window === "undefined") return
+    window.localStorage.setItem(STORAGE_KEY, String(remainingMs))
+  }, [remainingMs, isReady])
+
+  const deductTime = useCallback((milliseconds: number) => {
+    if (!Number.isFinite(milliseconds) || milliseconds <= 0) return
+
+    const delta = Math.round(milliseconds)
+    if (delta <= 0) return
+
+    setRemainingMs(prev =>
+      Math.max(0, Math.min(SESSION_DURATION_MS, prev - delta)),
+    )
+  }, [])
+
+  const reset = useCallback(() => {
+    setRemainingMs(SESSION_DURATION_MS)
+  }, [])
+
+  const value = useMemo(
+    () => ({ remainingMs, deductTime, reset }),
+    [remainingMs, deductTime, reset],
+  )
+
+  return (
+    <SessionTimeContext.Provider value={value}>
+      {children}
+    </SessionTimeContext.Provider>
+  )
+}
+
+export function useSessionTime() {
+  const ctx = useContext(SessionTimeContext)
+  if (!ctx) {
+    throw new Error("useSessionTime must be used within a SessionTimeProvider")
+  }
+  return ctx
+}
+
+export { SESSION_DURATION_MS }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 // 📄 Définition du layout racine de l'application Next.js.
 // Ce fichier englobe toutes les pages et applique la configuration globale
 // (polices, langue du document, styles partagés).
+import { SessionTimeProvider } from "@/app/context/SessionTimeContext";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -33,7 +34,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {/* Toutes les pages seront rendues ici */}
-        {children}
+        <SessionTimeProvider>{children}</SessionTimeProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- set the interview timer to a fixed 10 minutes and report elapsed seconds through the new `onStop` callback
- introduce a `SessionTimeContext` persisted in local storage and wrap the app with its provider
- deduct elapsed time when simulations finish and display the shared allowance via the updated remaining time badge

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68c992c73c2c8331b0b582c04e15b0d9