### PR TITLE
Refactor composer layout and add push-to-talk

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -2,7 +2,14 @@
 
 // 📝 Zone de composition des messages utilisateur.
 // Gère aussi le mode dictée vocale et la détection de silences prolongés.
-import { useRef, useState, useEffect, useCallback } from "react"
+import {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from "react"
+import type { KeyboardEvent, PointerEvent } from "react"
 import type { Message } from "./MessageList"
 
 type Props = {
@@ -14,11 +21,16 @@ type Props = {
 export default function Composer({ onSend, onSilence, disabled }: Props) {
   const [text, setText] = useState("")
   const [voiceMode, setVoiceMode] = useState(false)
+  const [audioLevel, setAudioLevel] = useState(0)
   const voiceModeRef = useRef(false)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const recognitionRef = useRef<any>(null)
   const silenceTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const wasVoiceModeRef = useRef(false)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+  const animationFrameRef = useRef<number | null>(null)
+  const dataArrayRef = useRef<Uint8Array | null>(null)
 
   // 🌐 Au montage, on teste la disponibilité de l'API Web Speech et on stocke
   // la classe de reconnaissance pour pouvoir l'instancier plus tard.
@@ -61,8 +73,96 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
     }, 10000)
   }, [onSilence])
 
-  // 🎙️ Active le mode reconnaissance vocale continue.
-  const startVoiceMode = useCallback(() => {
+  const clearSilenceTimer = useCallback(() => {
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current)
+      silenceTimerRef.current = null
+    }
+  }, [])
+
+  const stopAudioMeter = useCallback(() => {
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current)
+      animationFrameRef.current = null
+    }
+    mediaStreamRef.current?.getTracks().forEach(track => track.stop())
+    mediaStreamRef.current = null
+    analyserRef.current = null
+    dataArrayRef.current = null
+    if (audioContextRef.current) {
+      audioContextRef.current.close().catch(() => null)
+      audioContextRef.current = null
+    }
+    setAudioLevel(0)
+  }, [])
+
+  const startAudioMeter = useCallback(async () => {
+    if (audioContextRef.current) return
+
+    try {
+      if (
+        typeof navigator === "undefined" ||
+        !navigator.mediaDevices ||
+        !navigator.mediaDevices.getUserMedia
+      ) {
+        throw new Error("Captation audio non supportée")
+      }
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      mediaStreamRef.current = stream
+
+      const AudioContextClass =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).AudioContext ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).webkitAudioContext
+
+      if (!AudioContextClass) {
+        throw new Error("AudioContext non disponible")
+      }
+
+      const audioContext: AudioContext = new AudioContextClass()
+      audioContextRef.current = audioContext
+      const source = audioContext.createMediaStreamSource(stream)
+      const analyser = audioContext.createAnalyser()
+      analyser.fftSize = 2048
+      analyserRef.current = analyser
+      source.connect(analyser)
+      const dataArray = new Uint8Array(analyser.frequencyBinCount)
+      dataArrayRef.current = dataArray
+
+      const update = () => {
+        if (!analyserRef.current || !dataArrayRef.current) return
+        analyserRef.current.getByteTimeDomainData(dataArrayRef.current)
+        let sumSquares = 0
+        for (let i = 0; i < dataArrayRef.current.length; i += 1) {
+          const value = (dataArrayRef.current[i] - 128) / 128
+          sumSquares += value * value
+        }
+        const rms = Math.sqrt(sumSquares / dataArrayRef.current.length)
+        setAudioLevel(rms)
+        animationFrameRef.current = requestAnimationFrame(update)
+      }
+
+      update()
+    } catch (error) {
+      stopAudioMeter()
+      throw error
+    }
+  }, [stopAudioMeter])
+
+  // 🎙️ Active l'écoute vocale tant que le bouton est maintenu.
+  // ⏹️ Arrête proprement la dictée vocale et le timer de silence.
+  const stopVoiceMode = useCallback(() => {
+    if (!voiceModeRef.current) return
+    voiceModeRef.current = false
+    setVoiceMode(false)
+    clearSilenceTimer()
+    recognitionRef.current?.stop()
+    recognitionRef.current = null
+    stopAudioMeter()
+  }, [clearSilenceTimer, stopAudioMeter])
+
+  const startVoiceMode = useCallback(async () => {
     if (voiceModeRef.current || disabled) return
     const SpeechRecognition =
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,6 +173,26 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
       alert("La reconnaissance vocale n'est pas supportée par ce navigateur.")
       return
     }
+
+    voiceModeRef.current = true
+    setVoiceMode(true)
+
+    try {
+      await startAudioMeter()
+    } catch {
+      voiceModeRef.current = false
+      setVoiceMode(false)
+      alert(
+        "Impossible d'accéder au microphone. Vérifiez les permissions du navigateur."
+      )
+      return
+    }
+
+    if (!voiceModeRef.current) {
+      stopAudioMeter()
+      return
+    }
+
     const recognition: SpeechRecognition = new SpeechRecognition()
     recognition.lang = "fr-FR"
     recognition.continuous = true
@@ -88,32 +208,35 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
       resetSilenceTimer()
     }
     recognition.onerror = event => {
-      if (event.error === "no-speech") {
-        recognition.abort()
-        resetSilenceTimer()
-      } else {
-        setVoiceMode(false)
+      if (event.error !== "no-speech") {
+        stopVoiceMode()
       }
     }
     recognition.onend = () => {
-      if (voiceModeRef.current) {
-        recognition.start()
-      } else {
+      recognitionRef.current = null
+      if (!voiceModeRef.current) {
         setVoiceMode(false)
+        stopAudioMeter()
+        clearSilenceTimer()
       }
     }
     recognitionRef.current = recognition
-    recognition.start()
-    setVoiceMode(true)
-    resetSilenceTimer()
-  }, [disabled, onSend, resetSilenceTimer])
 
-  // ⏹️ Arrête proprement la dictée vocale et le timer de silence.
-  const stopVoiceMode = useCallback(() => {
-    setVoiceMode(false)
-    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
-    recognitionRef.current?.stop()
-  }, [])
+    try {
+      recognition.start()
+      resetSilenceTimer()
+    } catch {
+      stopVoiceMode()
+    }
+  }, [
+    clearSilenceTimer,
+    disabled,
+    onSend,
+    resetSilenceTimer,
+    startAudioMeter,
+    stopAudioMeter,
+    stopVoiceMode,
+  ])
 
   // Si l'utilisateur désactive l'envoi (timer arrêté), on coupe aussi la dictée.
   useEffect(() => {
@@ -127,29 +250,92 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
   useEffect(() => {
     const handleSpeakingStart = () => {
       if (voiceModeRef.current) {
-        if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
-        wasVoiceModeRef.current = true
-        recognitionRef.current?.stop()
-        setVoiceMode(false)
-      }
-    }
-    const handleSpeakingEnd = () => {
-      if (wasVoiceModeRef.current) {
-        wasVoiceModeRef.current = false
-        startVoiceMode()
+        stopVoiceMode()
       }
     }
     window.addEventListener("assistant-speaking-start", handleSpeakingStart)
-    window.addEventListener("assistant-speaking-end", handleSpeakingEnd)
     return () => {
       window.removeEventListener("assistant-speaking-start", handleSpeakingStart)
-      window.removeEventListener("assistant-speaking-end", handleSpeakingEnd)
     }
-  }, [startVoiceMode])
+  }, [stopVoiceMode])
+
+  useEffect(() => {
+    return () => {
+      stopVoiceMode()
+    }
+  }, [stopVoiceMode])
+
+  const audioLevelWidth = useMemo(() => {
+    if (!voiceMode) return "0%"
+    const normalized = Math.min(1, audioLevel * 4)
+    return `${Math.max(0.05, normalized) * 100}%`
+  }, [audioLevel, voiceMode])
+
+  const voiceButtonHandlers = {
+    onPointerDown: (event: PointerEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      if (event.pointerType === "mouse" && event.button !== 0) return
+      event.preventDefault()
+      void startVoiceMode()
+    },
+    onPointerUp: (event: PointerEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      event.preventDefault()
+      stopVoiceMode()
+    },
+    onPointerLeave: (event: PointerEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      if (event.pointerType === "mouse") {
+        stopVoiceMode()
+      }
+    },
+    onPointerCancel: () => {
+      if (disabled) return
+      stopVoiceMode()
+    },
+    onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      if (event.key === " " || event.key === "Enter") {
+        event.preventDefault()
+        void startVoiceMode()
+      }
+    },
+    onKeyUp: (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      if (event.key === " " || event.key === "Enter") {
+        event.preventDefault()
+        stopVoiceMode()
+      }
+    },
+  }
 
   return (
-    <div className="flex flex-col gap-2 p-3 rounded-2xl shadow bg-gray-50">
-      <div className="flex items-center gap-2">
+    <div className="flex w-full flex-col gap-2">
+      <div
+        className={`flex items-center gap-3 rounded-full border bg-white px-4 py-3 shadow transition-opacity ${
+          disabled ? "opacity-60" : ""
+        }`}
+      >
+        <button
+          type="button"
+          disabled={disabled}
+          className={`flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 ${
+            voiceMode
+              ? "bg-red-100 text-red-700"
+              : "bg-blue-50 text-blue-700 hover:bg-blue-100"
+          }`}
+          {...voiceButtonHandlers}
+        >
+          {voiceMode ? "Enregistrement…" : "Maintenir pour parler"}
+        </button>
+        <div className="flex h-8 items-center">
+          <div className="h-2 w-16 rounded-full bg-gray-200">
+            <div
+              className="h-full rounded-full bg-red-500 transition-[width] duration-75 ease-out"
+              style={{ width: audioLevelWidth }}
+            />
+          </div>
+        </div>
         <input
           type="text"
           value={text}
@@ -164,28 +350,19 @@ export default function Composer({ onSend, onSilence, disabled }: Props) {
             disabled ? "⏱️ Lancez le timer pour commencer" : "Écrire un message..."
           }
           disabled={disabled}
-          className="flex-1 rounded border px-3 py-2 disabled:bg-gray-100"
+          className="flex-1 border-none bg-transparent text-sm focus:outline-none"
         />
-        <button
-          onClick={voiceMode ? stopVoiceMode : startVoiceMode}
-          disabled={disabled}
-          className={`rounded-full p-2 text-gray-800 shadow disabled:opacity-50 ${
-            voiceMode ? "bg-red-200" : "bg-gray-200"
-          }`}
-        >
-          {voiceMode ? "⏹️" : "🎤"}
-        </button>
         <button
           onClick={handleSend}
           disabled={disabled}
-          className="rounded-2xl bg-blue-600 px-4 py-2 text-white shadow disabled:opacity-50"
+          className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow disabled:opacity-50"
         >
           Envoyer
         </button>
       </div>
 
       {disabled && (
-        <p className="text-sm text-red-600 flex items-center gap-1">
+        <p className="flex items-center gap-1 text-sm text-red-600">
           ⏱️ Lancez le timer pour commencer l’entretien
         </p>
       )}

--- a/app/components/InterviewPageClient.tsx
+++ b/app/components/InterviewPageClient.tsx
@@ -293,8 +293,17 @@ export default function InterviewPageClient() {
           deductTime(elapsedSeconds * 1000)
         }}
       />
-      <div className="w-128 h-128" style={{ position: "relative", top: 0, left: 96 }}>
-        <Avatar ref={avatarRef} />
+      <div className="flex flex-col items-center gap-4">
+        <div className="w-128 h-128" style={{ position: "relative", top: 0, left: 96 }}>
+          <Avatar ref={avatarRef} />
+        </div>
+        <Composer
+          onSend={msg =>
+            handleSend({ ...msg, id: "", role: "user", content: msg.content })
+          }
+          onSilence={handleSilence}
+          disabled={timerState !== "running"}
+        />
       </div>
       <MessageList messages={messages} />
 
@@ -336,13 +345,6 @@ export default function InterviewPageClient() {
         </div>
       )}
 
-      <Composer
-        onSend={msg =>
-          handleSend({ ...msg, id: "", role: "user", content: msg.content })
-        }
-        onSilence={handleSilence}
-        disabled={timerState !== "running"}
-      />
       {/* Boutons de reset et export PDF */}
       <Controls onClear={handleClear} messages={messages} summary={summary} />
     </main>


### PR DESCRIPTION
## Summary
- refactor the Composer UI into a single horizontal bar positioned beneath the avatar
- replace the toggle microphone by a push-to-talk control with keyboard and pointer support
- add an audio level meter driven by a Web Audio analyser while recording

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68ccfad632248331bae0cf52c860279c