### PR TITLE
feat: add summary modal with audio and download

### DIFF
--- a/app/components/Controls.tsx
+++ b/app/components/Controls.tsx
@@ -2,114 +2,148 @@
 
 // 🧾 Actions finales : remise à zéro de la conversation et export PDF.
 import { Message } from "@/app/components/MessageList"
+import { PersonaId } from "@/app/personas"
 import jsPDF from "jspdf"
 
 type Props = {
   onClear: () => void
   messages: Message[]
   summary: string | null
+  persona: PersonaId
 }
 
-export default function Controls({ onClear, messages, summary }: Props) {
+type DownloadParams = {
+  messages: Message[]
+  summary: string
+  persona: PersonaId
+}
+
+let downloadSequence = 1
+
+export const downloadConversationPdf = ({
+  messages,
+  summary,
+  persona,
+}: DownloadParams) => {
+  const doc = new jsPDF()
+  const pageWidth = doc.internal.pageSize.getWidth()
+  const pageHeight = doc.internal.pageSize.getHeight()
+  const margin = 10
+  const lineHeight = 7
+  let y = margin
+
+  // 🗨️ Dessine chaque bulle de message avec un code couleur par rôle.
+  messages.forEach(msg => {
+    const textLines = doc.splitTextToSize(
+      msg.content,
+      pageWidth - margin * 2 - 20
+    )
+    const textWidth = textLines.reduce(
+      (w: number, line: string) => Math.max(w, doc.getTextWidth(line)),
+      0
+    )
+    const bubbleWidth = textWidth + 6
+    const bubbleHeight = textLines.length * lineHeight + 6
+    if (y + bubbleHeight > pageHeight - margin) {
+      doc.addPage()
+      y = margin
+    }
+
+    let x = margin
+    let fill: [number, number, number] = [229, 231, 235]
+    let textColor: [number, number, number] = [31, 41, 55]
+
+    if (msg.role === "user") {
+      x = pageWidth - margin - bubbleWidth
+      fill = [59, 130, 246]
+      textColor = [255, 255, 255]
+    } else if (msg.role === "assistant") {
+      x = margin
+      fill = [229, 231, 235]
+      textColor = [31, 41, 55]
+    } else {
+      x = margin
+      fill = [254, 226, 226]
+      textColor = [185, 28, 28]
+    }
+
+    doc.setFillColor(...fill)
+    doc.setTextColor(...textColor)
+    doc.roundedRect(x, y, bubbleWidth, bubbleHeight, 4, 4, "F")
+    doc.text(textLines, x + 3, y + lineHeight)
+    doc.setTextColor(0, 0, 0)
+    y += bubbleHeight + 4
+  })
+
+  // 🧠 Ajout d'une nouvelle page pour la synthèse structurée.
+  doc.addPage()
+  doc.setFont("helvetica", "bold")
+  doc.setFontSize(18)
+  doc.text("Synthèse", margin, margin)
+  doc.setFont("helvetica", "normal")
+  doc.setFontSize(12)
+  y = margin + 10
+
+  const pageContentWidth = pageWidth - margin * 2
+  summary.split("\n").forEach(line => {
+    if (y > pageHeight - margin) {
+      doc.addPage()
+      y = margin
+    }
+    if (line.startsWith("# ")) {
+      doc.setFont("helvetica", "bold")
+      doc.setFontSize(16)
+      doc.text(line.slice(2), margin, y)
+      y += lineHeight + 2
+    } else if (line.startsWith("## ")) {
+      doc.setFont("helvetica", "bold")
+      doc.setFontSize(14)
+      doc.text(line.slice(3), margin, y)
+      y += lineHeight + 2
+    } else if (line.startsWith("- ") || line.startsWith("* ")) {
+      doc.setFont("helvetica", "normal")
+      doc.setFontSize(12)
+      const listLines = doc.splitTextToSize(
+        line.slice(2),
+        pageContentWidth - 5
+      )
+      doc.circle(margin + 2, y - 2, 1.5, "F")
+      doc.text(listLines, margin + 5, y)
+      y += listLines.length * lineHeight
+    } else if (line.trim() === "") {
+      y += lineHeight
+    } else {
+      doc.setFont("helvetica", "normal")
+      doc.setFontSize(12)
+      const paragraph = doc.splitTextToSize(line, pageContentWidth)
+      doc.text(paragraph, margin, y)
+      y += paragraph.length * lineHeight
+    }
+  })
+
+  const now = new Date()
+  const formattedDate = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("")
+  const sequence = String(downloadSequence).padStart(2, "0")
+  downloadSequence += 1
+  const fileName = `${formattedDate}_${sequence}_${persona}.pdf`
+
+  doc.save(fileName)
+}
+
+export default function Controls({
+  onClear,
+  messages,
+  summary,
+  persona,
+}: Props) {
   // 📥 Génère un PDF contenant l'historique et la synthèse finale.
   const handleDownload = () => {
     if (!summary || messages.length === 0) return
-    const doc = new jsPDF()
-    const pageWidth = doc.internal.pageSize.getWidth()
-    const pageHeight = doc.internal.pageSize.getHeight()
-    const margin = 10
-    const lineHeight = 7
-    let y = margin
-
-    // 🗨️ Dessine chaque bulle de message avec un code couleur par rôle.
-    messages.forEach(msg => {
-      const textLines = doc.splitTextToSize(
-        msg.content,
-        pageWidth - margin * 2 - 20
-      )
-      const textWidth = textLines.reduce(
-        (w: number, line: string) => Math.max(w, doc.getTextWidth(line)),
-        0
-      )
-      const bubbleWidth = textWidth + 6
-      const bubbleHeight = textLines.length * lineHeight + 6
-      if (y + bubbleHeight > pageHeight - margin) {
-        doc.addPage()
-        y = margin
-      }
-
-      let x = margin
-      let fill: [number, number, number] = [229, 231, 235]
-      let textColor: [number, number, number] = [31, 41, 55]
-
-      if (msg.role === "user") {
-        x = pageWidth - margin - bubbleWidth
-        fill = [59, 130, 246]
-        textColor = [255, 255, 255]
-      } else if (msg.role === "assistant") {
-        x = margin
-        fill = [229, 231, 235]
-        textColor = [31, 41, 55]
-      } else {
-        x = margin
-        fill = [254, 226, 226]
-        textColor = [185, 28, 28]
-      }
-
-      doc.setFillColor(...fill)
-      doc.setTextColor(...textColor)
-      doc.roundedRect(x, y, bubbleWidth, bubbleHeight, 4, 4, "F")
-      doc.text(textLines, x + 3, y + lineHeight)
-      doc.setTextColor(0, 0, 0)
-      y += bubbleHeight + 4
-    })
-
-    // 🧠 Ajout d'une nouvelle page pour la synthèse structurée.
-    doc.addPage()
-    doc.setFont("helvetica", "bold")
-    doc.setFontSize(18)
-    doc.text("Synthèse", margin, margin)
-    doc.setFont("helvetica", "normal")
-    doc.setFontSize(12)
-    y = margin + 10
-
-    const pageContentWidth = pageWidth - margin * 2
-    summary.split("\n").forEach(line => {
-      if (y > pageHeight - margin) {
-        doc.addPage()
-        y = margin
-      }
-      if (line.startsWith("# ")) {
-        doc.setFont("helvetica", "bold")
-        doc.setFontSize(16)
-        doc.text(line.slice(2), margin, y)
-        y += lineHeight + 2
-      } else if (line.startsWith("## ")) {
-        doc.setFont("helvetica", "bold")
-        doc.setFontSize(14)
-        doc.text(line.slice(3), margin, y)
-        y += lineHeight + 2
-      } else if (line.startsWith("- ") || line.startsWith("* ")) {
-        doc.setFont("helvetica", "normal")
-        doc.setFontSize(12)
-        const listLines = doc.splitTextToSize(
-          line.slice(2),
-          pageContentWidth - 5
-        )
-        doc.circle(margin + 2, y - 2, 1.5, "F")
-        doc.text(listLines, margin + 5, y)
-        y += listLines.length * lineHeight
-      } else if (line.trim() === "") {
-        y += lineHeight
-      } else {
-        doc.setFont("helvetica", "normal")
-        doc.setFontSize(12)
-        const paragraph = doc.splitTextToSize(line, pageContentWidth)
-        doc.text(paragraph, margin, y)
-        y += paragraph.length * lineHeight
-      }
-    })
-    doc.save("conversation.pdf")
+    downloadConversationPdf({ messages, summary, persona })
   }
 
   return (

--- a/app/components/SummaryModal.tsx
+++ b/app/components/SummaryModal.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import ReactMarkdown from "react-markdown"
+import type { Components } from "react-markdown"
+
+const markdownComponents: Components = {
+  h1: ({ ...props }) => (
+    <h1 className="text-2xl font-bold text-green-800 mb-4 border-b pb-2" {...props} />
+  ),
+  h2: ({ ...props }) => (
+    <h2 className="text-xl font-semibold text-green-700 mt-4 mb-2" {...props} />
+  ),
+  ul: ({ ...props }) => <ul className="list-disc list-inside space-y-1" {...props} />,
+  li: ({ ...props }) => <li className="leading-snug" {...props} />,
+  p: ({ ...props }) => <p className="my-1 leading-relaxed" {...props} />,
+}
+
+type SummaryModalProps = {
+  summary: string
+  onListen: () => void
+  onDownload: () => void
+  onClose: () => void
+}
+
+export default function SummaryModal({
+  summary,
+  onListen,
+  onDownload,
+  onClose,
+}: SummaryModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="relative max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-2xl border border-green-300 bg-green-50 p-6 shadow-xl">
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-700 transition hover:bg-green-200"
+          aria-label="Fermer la synthèse"
+        >
+          Fermer
+        </button>
+        <div className="flex flex-col gap-4 pr-2">
+          <div className="max-h-[60vh] overflow-y-auto pr-2">
+            <ReactMarkdown components={markdownComponents}>{summary}</ReactMarkdown>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={onListen}
+              className="rounded-2xl bg-emerald-600 px-4 py-2 text-white shadow hover:bg-emerald-700"
+            >
+              Écouter la synthèse
+            </button>
+            <button
+              onClick={onDownload}
+              className="rounded-2xl bg-blue-600 px-4 py-2 text-white shadow hover:bg-blue-700"
+            >
+              Télécharger le PDF
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- extract the generated summary display into a dedicated SummaryModal overlay
- add listen and download actions directly inside the summary modal
- share PDF generation logic and name files using the aaaammjj_nn_persona.pdf pattern

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cd05ab94748331a0307347d8dfefd3