### PR TITLE
Reset session and redirect after summary close

### DIFF
--- a/app/components/InterviewPageClient.tsx
+++ b/app/components/InterviewPageClient.tsx
@@ -352,7 +352,7 @@ export default function InterviewPageClient() {
           summary={summary}
           onListen={handleSummaryListen}
           onDownload={handleSummaryDownload}
-          onClose={() => setIsSummaryModalOpen(false)}
+          onClose={handleClear}
         />
       )}
     </main>

--- a/app/components/SummaryModal.tsx
+++ b/app/components/SummaryModal.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from "react-markdown"
 import type { Components } from "react-markdown"
+import { useRouter } from "next/navigation"
 
 const markdownComponents: Components = {
   h1: ({ ...props }) => (
@@ -28,11 +29,18 @@ export default function SummaryModal({
   onDownload,
   onClose,
 }: SummaryModalProps) {
+  const router = useRouter()
+
+  const handleClose = () => {
+    onClose()
+    router.push("/")
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
       <div className="relative max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-2xl border border-green-300 bg-green-50 p-6 shadow-xl">
         <button
-          onClick={onClose}
+          onClick={handleClose}
           className="absolute right-4 top-4 rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-700 transition hover:bg-green-200"
           aria-label="Fermer la synthèse"
         >


### PR DESCRIPTION
## Summary
- ensure the summary modal notifies the parent to reset the interview state before navigation
- trigger a redirect to the home page when the summary modal is closed by the user

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cd0d9d85b88331902d47958879fb37