### PR TITLE
Create dedicated landing experience for login access

### DIFF
--- a/app/components/landing/LandingAvatar.tsx
+++ b/app/components/landing/LandingAvatar.tsx
@@ -1,0 +1,23 @@
+export default function LandingAvatar() {
+  return (
+    <div className="relative mx-auto flex h-40 w-40 items-center justify-center rounded-full bg-gradient-to-br from-slate-100 via-slate-200 to-slate-100 shadow-xl">
+      <svg viewBox="0 0 160 160" className="h-36 w-36">
+        <defs>
+          <linearGradient id="skin" x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="0%" stopColor="#f2c6a8" />
+            <stop offset="100%" stopColor="#d8a482" />
+          </linearGradient>
+        </defs>
+        <circle cx="80" cy="80" r="70" fill="#2f4466" />
+        <circle cx="80" cy="70" r="45" fill="url(#skin)" />
+        <path d="M50 132c10-18 50-18 60 0" fill="#f5f5f5" />
+        <path d="M50 68c4-18 22-30 30-30s26 12 30 30" fill="#3b546f" />
+        <circle cx="62" cy="72" r="6" fill="#1d2a3a" />
+        <circle cx="98" cy="72" r="6" fill="#1d2a3a" />
+        <path d="M68 94c6 6 18 6 24 0" stroke="#1d2a3a" strokeWidth="4" strokeLinecap="round" fill="none" />
+        <path d="M64 112c8 6 24 6 32 0" stroke="#c9855f" strokeWidth="6" strokeLinecap="round" fill="none" />
+      </svg>
+      <div className="absolute -bottom-4 right-6 h-12 w-12 rounded-full bg-teal-400/90 shadow-lg shadow-teal-300/40" />
+    </div>
+  )
+}

--- a/app/components/landing/LandingCTAButton.tsx
+++ b/app/components/landing/LandingCTAButton.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link"
+
+export default function LandingCTAButton() {
+  return (
+    <Link
+      href="/login"
+      prefetch={false}
+      className="inline-flex min-w-[10rem] items-center justify-center rounded-full bg-cyan-500 px-6 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-cyan-500/40 transition hover:-translate-y-0.5 hover:bg-cyan-400"
+    >
+      Démarrer
+    </Link>
+  )
+}

--- a/app/components/landing/LandingChatMessage.tsx
+++ b/app/components/landing/LandingChatMessage.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react"
+
+type LandingChatMessageProps = {
+  author: string
+  children: ReactNode
+  align?: "left" | "right"
+}
+
+export default function LandingChatMessage({ author, children, align = "left" }: LandingChatMessageProps) {
+  const alignment = align === "left" ? "items-start" : "items-end"
+  const bubbleColor = align === "left" ? "bg-white text-slate-900" : "bg-cyan-500 text-slate-950"
+
+  return (
+    <div className={`flex w-full flex-col gap-1 ${alignment}`}>
+      <span className="text-xs font-medium text-white/60">{author}</span>
+      <div
+        className={`max-w-xs rounded-2xl px-4 py-3 text-sm shadow-lg shadow-slate-900/30 ${bubbleColor}`}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/app/components/landing/LandingHeadline.tsx
+++ b/app/components/landing/LandingHeadline.tsx
@@ -1,0 +1,15 @@
+export default function LandingHeadline() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h1 className="text-4xl font-semibold text-white md:text-5xl">
+          Simulation d&apos;entretiens professionnels
+        </h1>
+        <p className="max-w-lg text-base text-white/70 md:text-lg">
+          Exerzia est une application SaaS permettant de simuler des entretiens avec des
+          personnes réalistes.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/landing/LandingLoginLink.tsx
+++ b/app/components/landing/LandingLoginLink.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link"
+
+export default function LandingLoginLink() {
+  return (
+    <Link
+      href="/login"
+      className="text-sm font-semibold text-white transition hover:text-cyan-200"
+      prefetch={false}
+    >
+      Se connecter
+    </Link>
+  )
+}

--- a/app/components/landing/LandingLogo.tsx
+++ b/app/components/landing/LandingLogo.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link"
+
+export default function LandingLogo() {
+  return (
+    <Link href="/" className="flex items-center gap-3 text-white hover:opacity-90">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/90 shadow-lg shadow-cyan-500/30">
+        <span className="text-2xl font-bold">C</span>
+      </div>
+      <div className="flex flex-col leading-tight">
+        <span className="text-lg font-semibold tracking-wide">EXERZIA</span>
+        <span className="text-xs text-white/70">Coaching Virtuel</span>
+      </div>
+    </Link>
+  )
+}

--- a/app/components/landing/LandingMicButton.tsx
+++ b/app/components/landing/LandingMicButton.tsx
@@ -1,0 +1,14 @@
+export default function LandingMicButton() {
+  return (
+    <button
+      type="button"
+      className="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500 text-slate-950 shadow-lg shadow-cyan-500/40"
+      aria-label="Microphone"
+    >
+      <svg viewBox="0 0 24 24" className="h-6 w-6" fill="currentColor">
+        <path d="M12 15a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3z" />
+        <path d="M19 12a1 1 0 1 0-2 0 5 5 0 0 1-10 0 1 1 0 1 0-2 0 7 7 0 0 0 6 6.93V21H9a1 1 0 1 0 0 2h6a1 1 0 1 0 0-2h-2v-2.07A7 7 0 0 0 19 12z" />
+      </svg>
+    </button>
+  )
+}

--- a/app/components/landing/LandingPage.tsx
+++ b/app/components/landing/LandingPage.tsx
@@ -1,0 +1,29 @@
+import LandingCTAButton from "./LandingCTAButton"
+import LandingHeadline from "./LandingHeadline"
+import LandingLoginLink from "./LandingLoginLink"
+import LandingLogo from "./LandingLogo"
+import LandingPreviewCard from "./LandingPreviewCard"
+
+export default function LandingPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-br from-[#050b19] via-[#0b1832] to-[#040711]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.25),_transparent_55%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,_rgba(129,140,248,0.2),_transparent_55%)]" />
+
+      <header className="relative z-10 flex items-center justify-between px-10 py-8">
+        <LandingLogo />
+        <LandingLoginLink />
+      </header>
+
+      <section className="relative z-10 flex flex-1 items-center justify-center px-6 pb-12 md:px-12">
+        <div className="grid w-full max-w-6xl items-center gap-12 md:grid-cols-[minmax(0,_1fr)_minmax(0,_0.9fr)]">
+          <div className="space-y-10 text-white">
+            <LandingHeadline />
+            <LandingCTAButton />
+          </div>
+          <LandingPreviewCard />
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/components/landing/LandingPreviewCard.tsx
+++ b/app/components/landing/LandingPreviewCard.tsx
@@ -1,0 +1,28 @@
+import LandingAvatar from "./LandingAvatar"
+import LandingChatMessage from "./LandingChatMessage"
+import LandingMicButton from "./LandingMicButton"
+
+export default function LandingPreviewCard() {
+  return (
+    <div className="relative mx-auto flex w-full max-w-md flex-col gap-6 rounded-3xl bg-slate-900/60 p-8 text-white shadow-2xl shadow-black/40 backdrop-blur-lg">
+      <div className="absolute -top-10 -left-10 h-20 w-20 rounded-full bg-cyan-500/30 blur-3xl" />
+      <div className="absolute -bottom-12 -right-12 h-24 w-24 rounded-full bg-indigo-500/20 blur-3xl" />
+      <LandingAvatar />
+      <div className="flex flex-col gap-4">
+        <LandingChatMessage author="Coach AI">
+          Bonjour, je suis Alex, votre coach pour aujourd&apos;hui. Prêt à commencer ?
+        </LandingChatMessage>
+        <LandingChatMessage author="Vous" align="right">
+          Oui, je veux m&apos;entraîner pour mon prochain entretien.
+        </LandingChatMessage>
+      </div>
+      <div className="flex items-center justify-between rounded-2xl bg-slate-800/70 px-5 py-4">
+        <div>
+          <p className="text-sm font-semibold">Session en direct</p>
+          <p className="text-xs text-white/60">Activez votre micro pour répondre</p>
+        </div>
+        <LandingMicButton />
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,5 @@
-import InterviewPageClient from "@/app/components/InterviewPageClient"
-import { SESSION_COOKIE_NAME } from "@/app/lib/auth"
-import { cookies } from "next/headers"
-import { redirect } from "next/navigation"
+import LandingPage from "@/app/components/landing/LandingPage"
 
-export default function InterviewPage() {
-  const session = cookies().get(SESSION_COOKIE_NAME)
-
-  if (!session) {
-    redirect("/login")
-  }
-
-  return <InterviewPageClient />
+export default function HomePage() {
+  return <LandingPage />
 }


### PR DESCRIPTION
## Summary
- replace the home page with a persistent marketing-style landing screen encouraging users to log in
- introduce modular landing components for the logo, headline, CTA, avatar illustration, chat preview, and microphone button
- link the primary and secondary actions to the existing /login page so users can start the experience

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d50113a0988331ab06814cb590c175