### PR TITLE
Ensure login page is dynamically rendered

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,8 @@ import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import Link from "next/link"
 
+export const dynamic = "force-dynamic"
+
 const ERROR_MESSAGE = "Identifiant ou mot de passe invalide."
 
 type LoginPageProps = {


### PR DESCRIPTION
## Summary
- force the /login page to be rendered dynamically so cookie-based redirects are evaluated per request

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d508fa0d1483319ad960e9a515cb43