### PR TITLE
Render interview for authenticated sessions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,14 @@
+import InterviewPageClient from "@/app/components/InterviewPageClient"
 import LandingPage from "@/app/components/landing/LandingPage"
+import { SESSION_COOKIE_NAME } from "@/app/lib/auth"
+import { cookies } from "next/headers"
 
 export default function HomePage() {
-  return <LandingPage />
+  const session = cookies().get(SESSION_COOKIE_NAME)
+
+  if (!session) {
+    return <LandingPage />
+  }
+
+  return <InterviewPageClient />
 }


### PR DESCRIPTION
## Summary
- import the authentication cookie helpers and interview client on the home page
- serve the landing experience only for guests and the interview simulator for authenticated users

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d50c326b488331be88d323a81141a9