### PR TITLE
Fix live report popup storage handling

### DIFF
--- a/app/components/InterviewPageClient.tsx
+++ b/app/components/InterviewPageClient.tsx
@@ -333,7 +333,7 @@ export default function InterviewPageClient({
       const storageKey = `coachvisio-live-report-${Date.now()}`
 
       try {
-        window.sessionStorage.setItem(storageKey, JSON.stringify(payload))
+        window.localStorage.setItem(storageKey, JSON.stringify(payload))
       } catch {
         setMessages(prev => [
           ...prev,
@@ -354,6 +354,7 @@ export default function InterviewPageClient({
       )
 
       if (!reportWindow) {
+        window.localStorage.removeItem(storageKey)
         setMessages(prev => [
           ...prev,
           {

--- a/app/reports/live/page.tsx
+++ b/app/reports/live/page.tsx
@@ -41,7 +41,13 @@ export default function LiveReportPage() {
 
     if (typeof window === "undefined") return
 
-    const raw = window.sessionStorage.getItem(storageKey)
+    let raw: string | null = null
+    try {
+      raw = window.localStorage.getItem(storageKey)
+    } catch {
+      setError("Impossible de lire les données du bilan.")
+      return
+    }
     if (!raw) {
       setError("Les données du bilan sont introuvables ou ont expiré.")
       return
@@ -54,7 +60,7 @@ export default function LiveReportPage() {
       setError("Impossible de lire les données du bilan.")
       return
     } finally {
-      window.sessionStorage.removeItem(storageKey)
+      window.localStorage.removeItem(storageKey)
     }
   }, [storageKey])
 


### PR DESCRIPTION
## Summary
- store live report payloads in localStorage so the popup window can access them
- clear temporary payloads if the popup fails to open and after the viewer consumes them
- harden the live report page against storage access errors for clearer feedback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68da9b2510ac83318477658e81af1481