### PR TITLE
Fix ReactMarkdown usage in live report page

### DIFF
--- a/app/reports/live/page.tsx
+++ b/app/reports/live/page.tsx
@@ -135,22 +135,23 @@ export default function LiveReportPage() {
               </div>
 
               <div className="max-h-[60vh] overflow-y-auto rounded-2xl border border-white/10 bg-slate-900/30 p-6 shadow-inner shadow-cyan-500/20">
-                <ReactMarkdown
-                  className="prose prose-invert max-w-none text-white/90"
-                  components={{
-                    h1: props => (
-                      <h1 className="text-2xl font-semibold text-white" {...props} />
-                    ),
-                    h2: props => (
-                      <h2 className="mt-6 text-xl font-semibold text-white" {...props} />
-                    ),
-                    ul: props => (
-                      <ul className="list-disc space-y-2 pl-6 text-white/90" {...props} />
-                    ),
-                  }}
-                >
-                  {data.summary}
-                </ReactMarkdown>
+                <div className="prose prose-invert max-w-none text-white/90">
+                  <ReactMarkdown
+                    components={{
+                      h1: props => (
+                        <h1 className="text-2xl font-semibold text-white" {...props} />
+                      ),
+                      h2: props => (
+                        <h2 className="mt-6 text-xl font-semibold text-white" {...props} />
+                      ),
+                      ul: props => (
+                        <ul className="list-disc space-y-2 pl-6 text-white/90" {...props} />
+                      ),
+                    }}
+                  >
+                    {data.summary}
+                  </ReactMarkdown>
+                </div>
               </div>
             </section>
 


### PR DESCRIPTION
## Summary
- wrap the live report markdown renderer in a styled container div to avoid the removed className prop

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_b_68da9ea373d48331818af9af004f6ebb