### PR TITLE
Fix report route handler params typing for Next.js 15

### DIFF
--- a/app/api/reports/[id]/route.ts
+++ b/app/api/reports/[id]/route.ts
@@ -5,9 +5,9 @@ import { getReportFile } from "@/app/lib/reports"
 
 export const GET = async (
   request: NextRequest,
-  { params }: { params: { id: string } },
+  context: { params: Promise<{ id: string }> },
 ) => {
-  const { id } = params
+  const { id } = await context.params
   const reportFile = await getReportFile(id)
 
   if (!reportFile) {


### PR DESCRIPTION
## Summary
- adjust the report API route handler to use the new async params context signature expected by Next.js 15

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_b_68da9f4e57fc83318ac5e8655f65765a